### PR TITLE
Remove docker dependencies

### DIFF
--- a/lib/docker_functions.go
+++ b/lib/docker_functions.go
@@ -1,0 +1,40 @@
+package docker2aci
+
+import (
+	"strings"
+)
+
+const (
+	defaultIndex = "index.docker.io"
+)
+
+// splitReposName breaks a reposName into an index name and remote name
+func splitReposName(reposName string) (string, string) {
+	nameParts := strings.SplitN(reposName, "/", 2)
+	var indexName, remoteName string
+	if len(nameParts) == 1 || (!strings.Contains(nameParts[0], ".") &&
+		!strings.Contains(nameParts[0], ":") && nameParts[0] != "localhost") {
+		// This is a Docker Index repos (ex: samalba/hipache or ubuntu)
+		// 'docker.io'
+		indexName = defaultIndex
+		remoteName = reposName
+	} else {
+		indexName = nameParts[0]
+		remoteName = nameParts[1]
+	}
+	return indexName, remoteName
+}
+
+// Get a repos name and returns the right reposName + tag
+// The tag can be confusing because of a port in a repository name.
+//     Ex: localhost.localdomain:5000/samalba/hipache:latest
+func parseRepositoryTag(repos string) (string, string) {
+	n := strings.LastIndex(repos, ":")
+	if n < 0 {
+		return repos, ""
+	}
+	if tag := repos[n+1:]; !strings.Contains(tag, "/") {
+		return repos[:n], tag
+	}
+	return repos, ""
+}

--- a/lib/docker_types.go
+++ b/lib/docker_types.go
@@ -1,0 +1,51 @@
+package docker2aci
+
+import "time"
+
+// DockerImageData stores the JSON structure of a Docker image.
+// Taken and adapted from upstream Docker.
+type DockerImageData struct {
+	ID              string             `json:"id"`
+	Parent          string             `json:"parent,omitempty"`
+	Comment         string             `json:"comment,omitempty"`
+	Created         time.Time          `json:"created"`
+	Container       string             `json:"container,omitempty"`
+	ContainerConfig DockerImageConfig  `json:"container_config,omitempty"`
+	DockerVersion   string             `json:"docker_version,omitempty"`
+	Author          string             `json:"author,omitempty"`
+	Config          *DockerImageConfig `json:"config,omitempty"`
+	Architecture    string             `json:"architecture,omitempty"`
+	OS              string             `json:"os,omitempty"`
+	Checksum        string             `json:"checksum"`
+}
+
+// Note: the Config structure should hold only portable information about the container.
+// Here, "portable" means "independent from the host we are running on".
+// Non-portable information *should* appear in HostConfig.
+// Taken and adapted from upstream Docker.
+type DockerImageConfig struct {
+	Hostname        string
+	Domainname      string
+	User            string
+	Memory          int64  // Memory limit (in bytes)
+	MemorySwap      int64  // Total memory usage (memory + swap); set `-1' to disable swap
+	CpuShares       int64  // CPU shares (relative weight vs. other containers)
+	Cpuset          string // Cpuset 0-2, 0,1
+	AttachStdin     bool
+	AttachStdout    bool
+	AttachStderr    bool
+	PortSpecs       []string // Deprecated - Can be in the format of 8080/tcp
+	ExposedPorts    map[string]struct{}
+	Tty             bool // Attach standard streams to a tty, including stdin if it is not closed.
+	OpenStdin       bool // Open stdin
+	StdinOnce       bool // If true, close stdin after the 1 attached client disconnects.
+	Env             []string
+	Cmd             []string
+	Image           string // Name of the image as it was passed by the operator (eg. could be symbolic)
+	Volumes         map[string]struct{}
+	WorkingDir      string
+	Entrypoint      []string
+	NetworkDisabled bool
+	MacAddress      string
+	OnBuild         []string
+}

--- a/lib/types.go
+++ b/lib/types.go
@@ -1,0 +1,13 @@
+package docker2aci
+
+type RepoData struct {
+	Tokens    []string
+	Endpoints []string
+	Cookie    []string
+}
+
+type ParsedDockerURL struct {
+	IndexURL  string
+	ImageName string
+	Tag       string
+}


### PR DESCRIPTION
We depended on docker packages to use docker's json manifest structures
and to parse the registry URLs but they're in packages `parsers`,
`registry` and `runconfig` which are quite general and have a lot of
dependencies. This caused Godep to download a big chunk of docker's code
which is not desirable when integrating docker2aci with rocket, for
example.

This commit extracts the needed docker functions and structures so we
don't import docker packages anymore.