### PR TITLE
Add dockercfg authentication to a registry

### DIFF
--- a/lib/docker2aci.go
+++ b/lib/docker2aci.go
@@ -37,8 +37,9 @@ import (
 )
 
 const (
-	defaultTag    = "latest"
-	schemaVersion = "0.1.1"
+	defaultTag        = "latest"
+	schemaVersion     = "0.1.1"
+	dockercfgFileName = ".dockercfg"
 )
 
 // Convert generates ACI images from docker registry URLs.
@@ -134,7 +135,15 @@ func getRepoData(indexURL string, remote string) (*RepoData, error) {
 		return nil, err
 	}
 
-	// TODO(iaguis) add auth?
+	username, password, err := getAuthInfo(indexURL)
+	if err != nil {
+		return nil, fmt.Errorf("error getting authentication info: %v", err)
+	}
+
+	if username != "" && password != "" {
+		req.SetBasicAuth(username, password)
+	}
+
 	req.Header.Set("X-Docker-Token", "true")
 
 	res, err := client.Do(req)
@@ -170,6 +179,37 @@ func getRepoData(indexURL string, remote string) (*RepoData, error) {
 		Tokens:    tokens,
 		Cookie:    cookies,
 	}, nil
+}
+
+func getAuthInfo(indexServer string) (string, string, error) {
+	dockerCfgPath := path.Join(getHomeDir(), dockercfgFileName)
+
+	if _, err := os.Stat(dockerCfgPath); os.IsNotExist(err) {
+		return "", "", nil
+	}
+
+	j, err := ioutil.ReadFile(dockerCfgPath)
+	if err != nil {
+		return "", "", err
+	}
+
+	var dockerAuth map[string]DockerAuthConfig
+	if err := json.Unmarshal(j, &dockerAuth); err != nil {
+		return "", "", err
+	}
+
+	// the official auth uses the full address instead of the hostname
+	officialAddress := "https://" + indexServer + "/v1/"
+	if c, ok := dockerAuth[officialAddress]; ok {
+		return decodeDockerAuth(c.Auth)
+	}
+
+	// try the normal case
+	if c, ok := dockerAuth[indexServer]; ok {
+		return decodeDockerAuth(c.Auth)
+	}
+
+	return "", "", nil
 }
 
 func getImageIDFromTag(registry string, appName string, tag string, repoData *RepoData) (string, error) {

--- a/lib/docker_types.go
+++ b/lib/docker_types.go
@@ -63,3 +63,11 @@ type DockerImageConfig struct {
 	MacAddress      string
 	OnBuild         []string
 }
+
+type DockerAuthConfig struct {
+	Username      string `json:"username,omitempty"`
+	Password      string `json:"password,omitempty"`
+	Auth          string `json:"auth"`
+	Email         string `json:"email"`
+	ServerAddress string `json:"serveraddress,omitempty"`
+}

--- a/lib/util.go
+++ b/lib/util.go
@@ -15,7 +15,11 @@
 package docker2aci
 
 import (
+	"encoding/base64"
+	"fmt"
+	"os"
 	"path"
+	"runtime"
 	"strings"
 )
 
@@ -33,4 +37,25 @@ func makeEndpointsList(headers []string) []string {
 	}
 
 	return endpoints
+}
+
+func decodeDockerAuth(s string) (string, string, error) {
+	decoded, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return "", "", err
+	}
+	parts := strings.SplitN(string(decoded), ":", 2)
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("invalid auth configuration file")
+	}
+	user := parts[0]
+	password := strings.Trim(parts[1], "\x00")
+	return user, password, nil
+}
+
+func getHomeDir() string {
+	if runtime.GOOS == "windows" {
+		return os.Getenv("USERPROFILE")
+	}
+	return os.Getenv("HOME")
 }


### PR DESCRIPTION
This adds support for authentication to a registry using the .dockercfg
file in user's home directory.