### PR TITLE
Fix handling of layers with no entrypoint or command

### DIFF
--- a/lib/docker2aci.go
+++ b/lib/docker2aci.go
@@ -484,7 +484,7 @@ func getExecCommand(entrypoint []string, cmd []string) types.Exec {
 	}
 	command = append(entrypoint, cmd...)
 	// non-absolute paths are not allowed, fallback to "/bin/sh -c command"
-	if !filepath.IsAbs(command[0]) {
+	if len(command) > 0 && !filepath.IsAbs(command[0]) {
 		command_prefix := []string{"/bin/sh", "-c"}
 		command = append(command_prefix, strings.Join(command, " "))
 	}


### PR DESCRIPTION
Fixes an issue with an index out of range panic when processing a layer that
has no entry point or command specified. Simply adds a length check before
accessing the slice.

Discovered and tested against the `apcera/gnatsd` docker image.