### PR TITLE
Quote COMMAND in /bin/sh -c COMMAND

### DIFF
--- a/lib/docker2aci.go
+++ b/lib/docker2aci.go
@@ -486,7 +486,8 @@ func getExecCommand(entrypoint []string, cmd []string) types.Exec {
 	// non-absolute paths are not allowed, fallback to "/bin/sh -c command"
 	if len(command) > 0 && !filepath.IsAbs(command[0]) {
 		command_prefix := []string{"/bin/sh", "-c"}
-		command = append(command_prefix, strings.Join(command, " "))
+		quoted_command := quote(command)
+		command = append(command_prefix, strings.Join(quoted_command, " "))
 	}
 	return command
 }

--- a/lib/util.go
+++ b/lib/util.go
@@ -15,6 +15,7 @@
 package docker2aci
 
 import (
+	"fmt"
 	"path"
 	"strings"
 )
@@ -33,4 +34,14 @@ func makeEndpointsList(headers []string) []string {
 	}
 
 	return endpoints
+}
+
+func quote(l []string) []string {
+	var quoted []string
+
+	for _, s := range l {
+		quoted = append(quoted, fmt.Sprintf("%q", s))
+	}
+
+	return quoted
 }


### PR DESCRIPTION
If we don't quote every element of the command array, spaces inside
elements will be interpreted by the shell as separators.

Fixes coreos/rocket#631