### PR TITLE
Handle whiteout files

### DIFF
--- a/lib/util.go
+++ b/lib/util.go
@@ -18,6 +18,8 @@ import (
 	"fmt"
 	"path"
 	"strings"
+
+	"github.com/appc/spec/pkg/acirenderer"
 )
 
 func makeEndpointsList(headers []string) []string {
@@ -44,4 +46,26 @@ func quote(l []string) []string {
 	}
 
 	return quoted
+}
+
+func reverseImages(s acirenderer.Images) acirenderer.Images {
+	var o acirenderer.Images
+	for i := len(s) - 1; i >= 0; i-- {
+		o = append(o, s[i])
+	}
+
+	return o
+}
+
+func in(list []string, el string) bool {
+	return indexOf(list, el) != -1
+}
+
+func indexOf(list []string, el string) int {
+	for i, x := range list {
+		if el == x {
+			return i
+		}
+	}
+	return -1
 }


### PR DESCRIPTION
We were ignoring Docker's whiteout files so it's time to handle them.

To do that, we keep a white list of files (PathWhitelist). As we go
through the layers, we remove any files maked as whiteouts from the list
so so that, at any time, each layer ACI has the list of its desired
files and the ones of its parent layers.

We change order we process the images to start from the base image so
that we can generate the correct white lists. Then we reverse the image
list because acirenderer expects images starting from the upper layer.