### PR TITLE
Add authentication

### DIFF
--- a/lib/common/common.go
+++ b/lib/common/common.go
@@ -35,7 +35,7 @@ func ParseDockerURL(arg string) *types.ParsedDockerURL {
 	if tag == "" {
 		tag = defaultTag
 	}
-	indexURL, imageName := splitReposName(taglessRemote)
+	indexURL, imageName := SplitReposName(taglessRemote)
 
 	return &types.ParsedDockerURL{
 		IndexURL:  indexURL,

--- a/lib/common/docker_functions.go
+++ b/lib/common/docker_functions.go
@@ -15,15 +15,25 @@
 package common
 
 import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path"
+	"runtime"
 	"strings"
+
+	"github.com/appc/docker2aci/lib/types"
 )
 
 const (
-	defaultIndex = "index.docker.io"
+	defaultIndex      = "index.docker.io"
+	dockercfgFileName = ".dockercfg"
 )
 
 // splitReposName breaks a reposName into an index name and remote name
-func splitReposName(reposName string) (string, string) {
+func SplitReposName(reposName string) (string, string) {
 	nameParts := strings.SplitN(reposName, "/", 2)
 	var indexName, remoteName string
 	if len(nameParts) == 1 || (!strings.Contains(nameParts[0], ".") &&
@@ -51,4 +61,58 @@ func parseRepositoryTag(repos string) (string, string) {
 		return repos[:n], tag
 	}
 	return repos, ""
+}
+
+func decodeDockerAuth(s string) (string, string, error) {
+	decoded, err := base64.StdEncoding.DecodeString(s)
+	if err != nil {
+		return "", "", err
+	}
+	parts := strings.SplitN(string(decoded), ":", 2)
+	if len(parts) != 2 {
+		return "", "", fmt.Errorf("invalid auth configuration file")
+	}
+	user := parts[0]
+	password := strings.Trim(parts[1], "\x00")
+	return user, password, nil
+}
+
+func getHomeDir() string {
+	if runtime.GOOS == "windows" {
+		return os.Getenv("USERPROFILE")
+	}
+	return os.Getenv("HOME")
+}
+
+// GetDockercfgAuth reads a ~/.dockercfg file and returns the username and password
+// of the given docker index server.
+func GetAuthInfo(indexServer string) (string, string, error) {
+	dockerCfgPath := path.Join(getHomeDir(), dockercfgFileName)
+
+	if _, err := os.Stat(dockerCfgPath); os.IsNotExist(err) {
+		return "", "", nil
+	}
+
+	j, err := ioutil.ReadFile(dockerCfgPath)
+	if err != nil {
+		return "", "", err
+	}
+
+	var dockerAuth map[string]types.DockerAuthConfig
+	if err := json.Unmarshal(j, &dockerAuth); err != nil {
+		return "", "", err
+	}
+
+	// the official auth uses the full address instead of the hostname
+	officialAddress := "https://" + indexServer + "/v1/"
+	if c, ok := dockerAuth[officialAddress]; ok {
+		return decodeDockerAuth(c.Auth)
+	}
+
+	// try the normal case
+	if c, ok := dockerAuth[indexServer]; ok {
+		return decodeDockerAuth(c.Auth)
+	}
+
+	return "", "", nil
 }

--- a/lib/docker2aci.go
+++ b/lib/docker2aci.go
@@ -53,9 +53,10 @@ type Docker2ACIBackend interface {
 // If the squash flag is true, it squashes all the layers in one file and
 // places this file in outputDir; if it is false, it places every layer in its
 // own ACI in outputDir.
+// username and password can be passed if the image needs authentication.
 // It returns the list of generated ACI paths.
-func Convert(dockerURL string, squash bool, outputDir string) ([]string, error) {
-	repositoryBackend := repository.NewRepositoryBackend()
+func Convert(dockerURL string, squash bool, outputDir string, username string, password string) ([]string, error) {
+	repositoryBackend := repository.NewRepositoryBackend(username, password)
 	return convertReal(repositoryBackend, dockerURL, squash, outputDir)
 }
 
@@ -80,6 +81,18 @@ func ConvertFile(dockerURL string, filePath string, squash bool, outputDir strin
 
 	fileBackend := file.NewFileBackend(f)
 	return convertReal(fileBackend, dockerURL, squash, outputDir)
+}
+
+// GetIndexName returns the docker index server from a docker URL.
+func GetIndexName(dockerURL string) string {
+	index, _ := common.SplitReposName(dockerURL)
+	return index
+}
+
+// GetDockercfgAuth reads a ~/.dockercfg file and returns the username and password
+// of the given docker index server.
+func GetDockercfgAuth(indexServer string) (string, string, error) {
+	return common.GetAuthInfo(indexServer)
 }
 
 func convertReal(backend Docker2ACIBackend, dockerURL string, squash bool, outputDir string) ([]string, error) {

--- a/lib/types/docker_types.go
+++ b/lib/types/docker_types.go
@@ -63,3 +63,12 @@ type DockerImageConfig struct {
 	MacAddress      string
 	OnBuild         []string
 }
+
+// Taken from upstream Docker
+type DockerAuthConfig struct {
+	Username      string `json:"username,omitempty"`
+	Password      string `json:"password,omitempty"`
+	Auth          string `json:"auth"`
+	Email         string `json:"email"`
+	ServerAddress string `json:"serveraddress,omitempty"`
+}

--- a/main.go
+++ b/main.go
@@ -51,9 +51,17 @@ func runDocker2ACI(arg string, flagNoSquash bool, flagImage string, flagDebug bo
 		if flagImage != "" {
 			return fmt.Errorf("flag --image works only with files.")
 		}
-		registryURL := strings.TrimPrefix(arg, "docker://")
+		dockerURL := strings.TrimPrefix(arg, "docker://")
 
-		aciLayerPaths, err = docker2aci.Convert(registryURL, squash, ".")
+		indexServer := docker2aci.GetIndexName(dockerURL)
+
+		var username, password string
+		username, password, err = docker2aci.GetDockercfgAuth(indexServer)
+		if err != nil {
+			return fmt.Errorf("error reading .dockercfg file: %v", err)
+		}
+
+		aciLayerPaths, err = docker2aci.Convert(dockerURL, squash, ".", username, password)
 	} else {
 		aciLayerPaths, err = docker2aci.ConvertFile(flagImage, arg, squash, ".")
 	}


### PR DESCRIPTION
This adds username and password parameters to Convert() so users can
convert images that require authentication.

It also adds a public function GetDockercfgAuth() that parses a
.dockercfg file and returns the credentials of the given Docker index
server.

Finally, another public function GetIndexName() is provided so the user
can know which Docker index server corresponds to a Docker registry URL.

Addresses #7 