### PR TITLE
Convert Docker Volumes to mountPoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,17 @@ the correct dependencies.
 
 All ACIs generated are compressed with gzip.
 
-[aci]: https://github.com/appc/spec/blob/master/SPEC.md#app-container-image
+
+## Volumes
+
+Docker Volumes get converted to mountPoints in the
+[Image Manifest Schema][imageschema]. Since mountPoints need a name and Docker
+Volumes don't, docker2aci generates a name by appending the path to `volume-`.
+That is, if a Volume has `/var/tmp` as path, the resulting mountPoint name will
+be `volume-/var/tmp`.
+
+When the docker2aci CLI binary converts a Docker Volume to a mountPoint it will
+print its name, path and whether it is read-only or not.
 
 ## CLI examples
 
@@ -51,3 +61,34 @@ Extracting layer: 2103b00b3fdf1d26a86aded36ae73c1c425def0f779a6e69073b3b77377df3
 Generated ACI(s):
 ubuntu-latest.aci
 ```
+
+```
+$ ./docker2aci docker://redis
+Downloading layer: 511136ea3c5a64f264b78b5433614aec563103b4d4702f3ba7d4d2698e22c158
+Downloading layer: 4f903438061c7180cf99485b42f7709f5268bfb4732fe885f9104ed3bb66fd3c
+Downloading layer: 1265e16d0c286a4252c1dc5e775ba476d9560e2dd96d2032605ee75b30912f6b
+Downloading layer: 33b9d52d008c40bd2882f516490c449a85b706055421c13b0216b510c3d1fda0
+Downloading layer: 50d092d7db086395c16392b42c10e33587206b03b0f3bf886dcd78eeadf07c15
+Downloading layer: 1aa2ba847d032325c235f15837a78cdf1d48dac59c1ca036f04c982d76a4348d
+Downloading layer: e7fddb6710b0e122e24f880f0560c4d42655511a37c70dfcfe21aabc55bc86b0
+Downloading layer: 2dc7687bd0785d28a438bf9bca208d082d066915e2e388b08aeb6bcc82084a3e
+Downloading layer: c157a6ecc09ce072beac268c3a3e277aec11aef26b4b7ecb616aebec5d249ec5
+Downloading layer: 96b7fa01060d1d6ed52db4fea29c600a0a8bd8c1b75c119eb60a85114ad6c110
+Downloading layer: 607eb184411289059954fec63a321ef6408958d52efbf97966fb134b7cbeccca
+Downloading layer: a8beffce6b07225b9dfc2458c049e901cb748c1b58a6130a493fba2fd35b6b9e
+Downloading layer: b23ebc9e057634e7b402bb63ca835483796ecf60efd2e94be8eb45d0756851d0
+Downloading layer: c817c8c769d0120041f428a89ae270d4b616f8eed760b1cc96b0efaecd5e78d8
+Downloading layer: 19682c2cca49564c691ac06052de49f61d5bdf16c9203cf83b123903a6f052eb
+Downloading layer: 4a418129851356d0f07dc8be4455c3f8a15d11ac4bb3410eb799a647da6832ba
+Downloading layer: d47fc7449244382dc6121e68100a2c677f4964b495c5bdbbe2975be21777151e
+Downloading layer: f2fb89b0a711a7178528c7785d247ba3572924353b0d5e23e9b28f0518253b22
+
+Converted volumes:
+    name: "volume-/data", path: "/data", readOnly: false
+
+Generated ACI(s):
+redis-latest.aci
+```
+
+[aci]: https://github.com/appc/spec/blob/master/SPEC.md#app-container-image
+[imageschema]: https://github.com/appc/spec/blob/master/SPEC.md#image-manifest-schema

--- a/lib/common/common.go
+++ b/lib/common/common.go
@@ -185,12 +185,21 @@ func GenerateManifest(layerData types.DockerImageData, dockerURL *types.ParsedDo
 
 func convertVolumesToMPs(dockerVolumes map[string]struct{}) ([]appctypes.MountPoint, error) {
 	mps := []appctypes.MountPoint{}
+	dup := make(map[string]int)
 
 	for p := range dockerVolumes {
 		n := filepath.Join("volume-", p)
 		sn, err := appctypes.SanitizeACName(n)
 		if err != nil {
 			return nil, err
+		}
+
+		// check for duplicate names
+		if i, ok := dup[sn]; ok {
+			dup[sn] = i + 1
+			sn = fmt.Sprintf("%s-%d", sn, i)
+		} else {
+			dup[sn] = 1
 		}
 
 		mp := appctypes.MountPoint{

--- a/lib/common/common.go
+++ b/lib/common/common.go
@@ -160,6 +160,20 @@ func GenerateManifest(layerData types.DockerImageData, dockerURL *types.ParsedDo
 				WorkingDirectory: dockerConfig.WorkingDir,
 			}
 			genManifest.App = app
+
+			for p := range dockerConfig.Volumes {
+				n := filepath.Join("volume-", p)
+				sn, err := appctypes.SanitizeACName(n)
+				if err != nil {
+					return nil, err
+				}
+				mp := appctypes.MountPoint{
+					Name: *appctypes.MustACName(sn),
+					Path: p,
+				}
+
+				genManifest.App.MountPoints = append(genManifest.App.MountPoints, mp)
+			}
 		}
 	}
 

--- a/main.go
+++ b/main.go
@@ -23,6 +23,9 @@ import (
 
 	"github.com/appc/docker2aci/lib"
 	"github.com/appc/docker2aci/lib/util"
+
+	"github.com/appc/spec/aci"
+	"github.com/appc/spec/schema/types"
 )
 
 var (
@@ -65,12 +68,53 @@ func runDocker2ACI(arg string, flagNoSquash bool, flagImage string, flagDebug bo
 		return fmt.Errorf("conversion error: %v", err)
 	}
 
+	if squash {
+		if err := printConvertedVolumes(aciLayerPaths[0]); err != nil {
+			return err
+		}
+	}
+
 	fmt.Printf("\nGenerated ACI(s):\n")
 	for _, aciFile := range aciLayerPaths {
 		fmt.Println(aciFile)
 	}
 
 	return nil
+}
+
+func printConvertedVolumes(aciPath string) error {
+	mps, err := getMountPoints(aciPath)
+	if err != nil {
+		return err
+	}
+
+	if len(mps) > 0 {
+		fmt.Printf("\nConverted volumes:\n")
+		for _, mp := range mps {
+			fmt.Printf("\tname: %q, path: %q, readOnly: %v\n", mp.Name, mp.Path, mp.ReadOnly)
+		}
+	}
+
+	return nil
+}
+
+func getMountPoints(aciPath string) ([]types.MountPoint, error) {
+	f, err := os.Open(aciPath)
+	if err != nil {
+		return nil, fmt.Errorf("error opening converted image: %v", err)
+	}
+	defer f.Close()
+
+	manifest, err := aci.ManifestFromImage(f)
+	if err != nil {
+		return nil, fmt.Errorf("error reading manifest from converted image: %v", err)
+	}
+
+	if manifest.App != nil && manifest.App.MountPoints != nil {
+		return manifest.App.MountPoints, nil
+	}
+
+	return []types.MountPoint{}, nil
 }
 
 func usage() {

--- a/main.go
+++ b/main.go
@@ -68,10 +68,11 @@ func runDocker2ACI(arg string, flagNoSquash bool, flagImage string, flagDebug bo
 		return fmt.Errorf("conversion error: %v", err)
 	}
 
-	if squash {
-		if err := printConvertedVolumes(aciLayerPaths[0]); err != nil {
-			return err
-		}
+	// we print last layer's converted volumes, this will include all the
+	// volumes in the previous layers. If we're squashing, the last element of
+	// aciLayerPaths will be the squashed image.
+	if err := printConvertedVolumes(aciLayerPaths[len(aciLayerPaths)-1]); err != nil {
+		return err
 	}
 
 	fmt.Printf("\nGenerated ACI(s):\n")


### PR DESCRIPTION
A Docker image can specify Volumes which are akin to mountPoints in the
appc spec. This commit converts Volumes to mountPoints allowing the user
to mount volumes with rkt's --volume option.

Since Docker doesn't name Volumes but the appc spec requires a name, we
generate a name by appending the path to "volume-". That is, if a Volume
has "/var/tmp" as path, the resulting mountPoint name will be
"volume-/var/tmp". A mountPoint name must be a valid ACName so any
invalid characters will be replaced by a "-".