### PR TITLE
lib: add the tmpDir parameter (again)

### DIFF
--- a/lib/backend/file/file.go
+++ b/lib/backend/file/file.go
@@ -44,8 +44,8 @@ func (lb *FileBackend) GetImageInfo(dockerURL string) ([]string, *types.ParsedDo
 	return ancestry, parsedDockerURL, nil
 }
 
-func (lb *FileBackend) BuildACI(layerID string, dockerURL *types.ParsedDockerURL, outputDir string, curPwl []string, compress bool) (string, *schema.ImageManifest, error) {
-	tmpDir, err := ioutil.TempDir("", "docker2aci-")
+func (lb *FileBackend) BuildACI(layerID string, dockerURL *types.ParsedDockerURL, outputDir string, tmpBaseDir string, curPwl []string, compress bool) (string, *schema.ImageManifest, error) {
+	tmpDir, err := ioutil.TempDir(tmpBaseDir, "docker2aci-")
 	if err != nil {
 		return "", nil, fmt.Errorf("error creating dir: %v", err)
 	}

--- a/lib/backend/repository/repository.go
+++ b/lib/backend/repository/repository.go
@@ -61,8 +61,8 @@ func (rb *RepositoryBackend) GetImageInfo(url string) ([]string, *types.ParsedDo
 	return ancestry, dockerURL, nil
 }
 
-func (rb *RepositoryBackend) BuildACI(layerID string, dockerURL *types.ParsedDockerURL, outputDir string, curPwl []string, compress bool) (string, *schema.ImageManifest, error) {
-	tmpDir, err := ioutil.TempDir("", "docker2aci-")
+func (rb *RepositoryBackend) BuildACI(layerID string, dockerURL *types.ParsedDockerURL, outputDir string, tmpBaseDir string, curPwl []string, compress bool) (string, *schema.ImageManifest, error) {
+	tmpDir, err := ioutil.TempDir(tmpBaseDir, "docker2aci-")
 	if err != nil {
 		return "", nil, fmt.Errorf("error creating dir: %v", err)
 	}

--- a/lib/common/common.go
+++ b/lib/common/common.go
@@ -189,14 +189,14 @@ func GenerateManifest(layerData types.DockerImageData, dockerURL *types.ParsedDo
 	}
 
 	if layerData.Parent != "" {
-		parentAppNameString := dockerURL.IndexURL + "/" + dockerURL.ImageName + "-" + layerData.Parent
-		parentAppNameString, err := appctypes.SanitizeACName(parentAppNameString)
+		parentImageNameString := dockerURL.IndexURL + "/" + dockerURL.ImageName + "-" + layerData.Parent
+		parentImageNameString, err := appctypes.SanitizeACName(parentImageNameString)
 		if err != nil {
 			return nil, err
 		}
-		parentAppName := appctypes.MustACName(parentAppNameString)
+		parentImageName := appctypes.MustACName(parentImageNameString)
 
-		genManifest.Dependencies = append(genManifest.Dependencies, appctypes.Dependency{App: *parentAppName, Labels: parentLabels})
+		genManifest.Dependencies = append(genManifest.Dependencies, appctypes.Dependency{ImageName: *parentImageName, Labels: parentLabels})
 	}
 
 	return genManifest, nil

--- a/lib/common/common.go
+++ b/lib/common/common.go
@@ -189,14 +189,14 @@ func GenerateManifest(layerData types.DockerImageData, dockerURL *types.ParsedDo
 	}
 
 	if layerData.Parent != "" {
-		parentImageNameString := dockerURL.IndexURL + "/" + dockerURL.ImageName + "-" + layerData.Parent
-		parentImageNameString, err := appctypes.SanitizeACName(parentImageNameString)
+		parentAppNameString := dockerURL.IndexURL + "/" + dockerURL.ImageName + "-" + layerData.Parent
+		parentAppNameString, err := appctypes.SanitizeACName(parentAppNameString)
 		if err != nil {
 			return nil, err
 		}
-		parentImageName := appctypes.MustACName(parentImageNameString)
+		parentAppName := appctypes.MustACName(parentAppNameString)
 
-		genManifest.Dependencies = append(genManifest.Dependencies, appctypes.Dependency{ImageName: *parentImageName, Labels: parentLabels})
+		genManifest.Dependencies = append(genManifest.Dependencies, appctypes.Dependency{App: *parentAppName, Labels: parentLabels})
 	}
 
 	return genManifest, nil

--- a/lib/docker2aci.go
+++ b/lib/docker2aci.go
@@ -40,7 +40,7 @@ import (
 
 type Docker2ACIBackend interface {
 	GetImageInfo(dockerUrl string) ([]string, *types.ParsedDockerURL, error)
-	BuildACI(layerID string, dockerURL *types.ParsedDockerURL, outputDir string, curPWl []string, compress bool) (string, *schema.ImageManifest, error)
+	BuildACI(layerID string, dockerURL *types.ParsedDockerURL, outputDir string, tmpBaseDir string, curPWl []string, compress bool) (string, *schema.ImageManifest, error)
 }
 
 // Convert generates ACI images from docker registry URLs.
@@ -124,7 +124,7 @@ func convertReal(backend Docker2ACIBackend, dockerURL string, squash bool, outpu
 		layerID := ancestry[i]
 
 		// only compress individual layers if we're not squashing
-		aciPath, manifest, err := backend.BuildACI(layerID, parsedDockerURL, layersOutputDir, curPwl, !squash)
+		aciPath, manifest, err := backend.BuildACI(layerID, parsedDockerURL, layersOutputDir, tmpDir, curPwl, !squash)
 		if err != nil {
 			return nil, fmt.Errorf("error building layer: %v", err)
 		}


### PR DESCRIPTION
First, this revert a patch so that docker2aci compiles against appc/spec v0.5.2 rather than just git-master. It will be useful for rkt, see https://github.com/coreos/rkt/pull/929#issuecomment-104787060.

Then, add the tmpDir parameter to fix #50. It was partially done in #51 but not completely.

