### PR TITLE
Fix build by replacing ACName with ACIdentifier as in the spec

### DIFF
--- a/lib/common/common.go
+++ b/lib/common/common.go
@@ -105,11 +105,11 @@ func GenerateManifest(layerData types.DockerImageData, dockerURL *types.ParsedDo
 		appURL = dockerURL.IndexURL + "/"
 	}
 	appURL += dockerURL.ImageName + "-" + layerData.ID
-	appURL, err := appctypes.SanitizeACName(appURL)
+	appURL, err := appctypes.SanitizeACIdentifier(appURL)
 	if err != nil {
 		return nil, err
 	}
-	name := appctypes.MustACName(appURL)
+	name := appctypes.MustACIdentifier(appURL)
 	genManifest.Name = *name
 
 	acVersion, err := appctypes.NewSemVer(schemaVersion)
@@ -126,20 +126,20 @@ func GenerateManifest(layerData types.DockerImageData, dockerURL *types.ParsedDo
 		annotations  appctypes.Annotations
 	)
 
-	layer := appctypes.MustACName("layer")
+	layer := appctypes.MustACIdentifier("layer")
 	labels = append(labels, appctypes.Label{Name: *layer, Value: layerData.ID})
 
 	tag := dockerURL.Tag
-	version := appctypes.MustACName("version")
+	version := appctypes.MustACIdentifier("version")
 	labels = append(labels, appctypes.Label{Name: *version, Value: tag})
 
 	if layerData.OS != "" {
-		os := appctypes.MustACName("os")
+		os := appctypes.MustACIdentifier("os")
 		labels = append(labels, appctypes.Label{Name: *os, Value: layerData.OS})
 		parentLabels = append(parentLabels, appctypes.Label{Name: *os, Value: layerData.OS})
 
 		if layerData.Architecture != "" {
-			arch := appctypes.MustACName("arch")
+			arch := appctypes.MustACIdentifier("arch")
 			parentLabels = append(parentLabels, appctypes.Label{Name: *arch, Value: layerData.Architecture})
 		}
 	}
@@ -194,11 +194,11 @@ func GenerateManifest(layerData types.DockerImageData, dockerURL *types.ParsedDo
 
 	if layerData.Parent != "" {
 		parentImageNameString := dockerURL.IndexURL + "/" + dockerURL.ImageName + "-" + layerData.Parent
-		parentImageNameString, err := appctypes.SanitizeACName(parentImageNameString)
+		parentImageNameString, err := appctypes.SanitizeACIdentifier(parentImageNameString)
 		if err != nil {
 			return nil, err
 		}
-		parentImageName := appctypes.MustACName(parentImageNameString)
+		parentImageName := appctypes.MustACIdentifier(parentImageNameString)
 
 		genManifest.Dependencies = append(genManifest.Dependencies, appctypes.Dependency{ImageName: *parentImageName, Labels: parentLabels})
 	}
@@ -262,7 +262,7 @@ func convertVolumesToMPs(dockerVolumes map[string]struct{}) ([]appctypes.MountPo
 
 	for p := range dockerVolumes {
 		n := filepath.Join("volume-", p)
-		sn, err := appctypes.SanitizeACName(n)
+		sn, err := appctypes.SanitizeACIdentifier(n)
 		if err != nil {
 			return nil, err
 		}

--- a/lib/common/common.go
+++ b/lib/common/common.go
@@ -262,7 +262,7 @@ func convertVolumesToMPs(dockerVolumes map[string]struct{}) ([]appctypes.MountPo
 
 	for p := range dockerVolumes {
 		n := filepath.Join("volume-", p)
-		sn, err := appctypes.SanitizeACIdentifier(n)
+		sn, err := appctypes.SanitizeACName(n)
 		if err != nil {
 			return nil, err
 		}

--- a/lib/common/common.go
+++ b/lib/common/common.go
@@ -154,7 +154,7 @@ func GenerateManifest(layerData types.DockerImageData, dockerURL *types.ParsedDo
 		annotations = append(annotations, appctypes.Annotation{Name: *createdKey, Value: layerData.Created.Format(time.RFC3339)})
 	}
 	if layerData.Comment != "" {
-		commentKey := appctypes.MustACName("docker/comment")
+		commentKey := appctypes.MustACName("docker-comment")
 		annotations = append(annotations, appctypes.Annotation{Name: *commentKey, Value: layerData.Comment})
 	}
 
@@ -247,8 +247,13 @@ func parseDockerPort(dockerPort string) (*appctypes.Port, error) {
 		return nil, fmt.Errorf("error parsing port %q: %v", portString, err)
 	}
 
+	sn, err := appctypes.SanitizeACName(dockerPort)
+	if err != nil {
+		return nil, err
+	}
+
 	appcPort := &appctypes.Port{
-		Name:     *appctypes.MustACName(dockerPort),
+		Name:     *appctypes.MustACName(sn),
 		Protocol: proto,
 		Port:     uint(port),
 	}
@@ -261,7 +266,7 @@ func convertVolumesToMPs(dockerVolumes map[string]struct{}) ([]appctypes.MountPo
 	dup := make(map[string]int)
 
 	for p := range dockerVolumes {
-		n := filepath.Join("volume-", p)
+		n := filepath.Join("volume", p)
 		sn, err := appctypes.SanitizeACName(n)
 		if err != nil {
 			return nil, err

--- a/lib/conversion_store.go
+++ b/lib/conversion_store.go
@@ -72,7 +72,7 @@ func (ms *ConversionStore) GetImageManifest(key string) (*schema.ImageManifest, 
 	return aci.ImageManifest, nil
 }
 
-func (ms *ConversionStore) GetACI(name types.ACName, labels types.Labels) (string, error) {
+func (ms *ConversionStore) GetACI(name types.ACIdentifier, labels types.Labels) (string, error) {
 	for _, aci := range ms.acis {
 		// we implement this function to comply with the interface so don't
 		// bother implementing a proper label check

--- a/lib/docker2aci.go
+++ b/lib/docker2aci.go
@@ -281,7 +281,7 @@ func mergeManifests(manifests []schema.ImageManifest) schema.ImageManifest {
 	}
 
 	// this can't fail because the old name is legal
-	nameWithoutLayerID, _ := appctypes.NewACName(stripLayerID(manifest.Name.String()))
+	nameWithoutLayerID, _ := appctypes.NewACIdentifier(stripLayerID(manifest.Name.String()))
 
 	manifest.Name = *nameWithoutLayerID
 

--- a/lib/docker2aci.go
+++ b/lib/docker2aci.go
@@ -280,8 +280,7 @@ func mergeManifests(manifests []schema.ImageManifest) schema.ImageManifest {
 		manifest.Labels = append(manifest.Labels[:layerIndex], manifest.Labels[layerIndex+1:]...)
 	}
 
-	// this can't fail because the old name is legal
-	nameWithoutLayerID, _ := appctypes.NewACIdentifier(stripLayerID(manifest.Name.String()))
+	nameWithoutLayerID := appctypes.MustACIdentifier(stripLayerID(manifest.Name.String()))
 
 	manifest.Name = *nameWithoutLayerID
 


### PR DESCRIPTION
Hi,
docker2aci wasn't building anymore so I tried to fix this by changing ACName to ACIdentifier where needed.
I think this was broken since https://github.com/appc/spec/pull/398 has been merged.