### PR TITLE
common: add arch label to the manifest

### DIFF
--- a/lib/common/common.go
+++ b/lib/common/common.go
@@ -140,6 +140,7 @@ func GenerateManifest(layerData types.DockerImageData, dockerURL *types.ParsedDo
 
 		if layerData.Architecture != "" {
 			arch := appctypes.MustACIdentifier("arch")
+			labels = append(labels, appctypes.Label{Name: *arch, Value: layerData.Architecture})
 			parentLabels = append(parentLabels, appctypes.Label{Name: *arch, Value: layerData.Architecture})
 		}
 	}


### PR DESCRIPTION
We forgot to add the arch label when converting Docker layer data to an
image manifest.