### PR TITLE
common: add additional docker informations to manifest.

### DIFF
--- a/lib/common/common.go
+++ b/lib/common/common.go
@@ -22,8 +22,13 @@ import (
 )
 
 const (
-	defaultTag    = "latest"
-	schemaVersion = "0.5.1"
+	defaultTag                = "latest"
+	schemaVersion             = "0.6.1"
+	appcDockerV1RegistryURL   = "appc.io/docker/v1/registryurl"
+	appcDockerV1Repository    = "appc.io/docker/v1/repository"
+	appcDockerV1Tag           = "appc.io/docker/v1/tag"
+	appcDockerV1ImageID       = "appc.io/docker/v1/imageid"
+	appcDockerV1ParentImageID = "appc.io/docker/v1/parentimageid"
 )
 
 func ParseDockerURL(arg string) *types.ParsedDockerURL {
@@ -159,6 +164,11 @@ func GenerateManifest(layerData types.DockerImageData, dockerURL *types.ParsedDo
 		annotations = append(annotations, appctypes.Annotation{Name: *commentKey, Value: layerData.Comment})
 	}
 
+	annotations = append(annotations, appctypes.Annotation{Name: *appctypes.MustACIdentifier(appcDockerV1RegistryURL), Value: dockerURL.IndexURL})
+	annotations = append(annotations, appctypes.Annotation{Name: *appctypes.MustACIdentifier(appcDockerV1Repository), Value: dockerURL.ImageName})
+	annotations = append(annotations, appctypes.Annotation{Name: *appctypes.MustACIdentifier(appcDockerV1ImageID), Value: layerData.ID})
+	annotations = append(annotations, appctypes.Annotation{Name: *appctypes.MustACIdentifier(appcDockerV1ParentImageID), Value: layerData.Parent})
+
 	genManifest.Labels = labels
 	genManifest.Annotations = annotations
 
@@ -202,6 +212,8 @@ func GenerateManifest(layerData types.DockerImageData, dockerURL *types.ParsedDo
 		parentImageName := appctypes.MustACIdentifier(parentImageNameString)
 
 		genManifest.Dependencies = append(genManifest.Dependencies, appctypes.Dependency{ImageName: *parentImageName, Labels: parentLabels})
+
+		annotations = append(annotations, appctypes.Annotation{Name: *appctypes.MustACIdentifier(appcDockerV1Tag), Value: dockerURL.Tag})
 	}
 
 	return genManifest, nil


### PR DESCRIPTION
This patch tries to implement the idea from #15.

This adds additional docker informations to the image manifest.
Now the v1 registry informations are added under the `appc.io/docker/v1/`
namespace:

`appc.io/docker/v1/indexurl`
`appc.io/docker/v1/repository`
`appc.io/docker/v1/tag`
`appc.io/docker/v1/imageid`
`appc.io/docker/v1/parentimageid`

Before adding a WELLKNOWN.md like proposed I'd like to get suggestions on the annotation names. For example `indexurl` should be `registryurl`?

This can be useful for getting docker v1 caching infos like proposed in https://github.com/coreos/rkt/issues/1196#issuecomment-127983674 without the need to save the imageID info in a store sql table.
