### PR TITLE
lib: fix multiple rootfs entries

### DIFF
--- a/lib/docker2aci.go
+++ b/lib/docker2aci.go
@@ -241,8 +241,8 @@ func writeSquashedImage(outputFile *os.File, renderedACI acirenderer.RenderedACI
 			cleanName := filepath.Clean(t.Name())
 
 			if _, ok := aciFile.FileMap[cleanName]; ok {
-				// we generate and add the squashed manifest later
-				if cleanName == "manifest" {
+				// we generate and add rootfs and the squashed manifest later
+				if cleanName == "manifest" || cleanName == "rootfs" {
 					return nil
 				}
 				if err := outputWriter.WriteHeader(t.Header); err != nil {


### PR DESCRIPTION
acirenderer adds a rootfs entry since
https://github.com/appc/spec/pull/437

Hence, we need to ignore it because we write our own rootfs entry.

Fixes #94 