### PR TITLE
adds support for the V2 HTTP API

### DIFF
--- a/lib/backend/file/file.go
+++ b/lib/backend/file/file.go
@@ -44,7 +44,7 @@ func (lb *FileBackend) GetImageInfo(dockerURL string) ([]string, *types.ParsedDo
 	return ancestry, parsedDockerURL, nil
 }
 
-func (lb *FileBackend) BuildACI(layerID string, dockerURL *types.ParsedDockerURL, outputDir string, tmpBaseDir string, curPwl []string, compress bool) (string, *schema.ImageManifest, error) {
+func (lb *FileBackend) BuildACI(layerNumber int, layerID string, dockerURL *types.ParsedDockerURL, outputDir string, tmpBaseDir string, curPwl []string, compress bool) (string, *schema.ImageManifest, error) {
 	tmpDir, err := ioutil.TempDir(tmpBaseDir, "docker2aci-")
 	if err != nil {
 		return "", nil, fmt.Errorf("error creating dir: %v", err)
@@ -71,7 +71,7 @@ func (lb *FileBackend) BuildACI(layerID string, dockerURL *types.ParsedDockerURL
 	defer layerFile.Close()
 
 	util.Debug("Generating layer ACI...")
-	aciPath, manifest, err := common.GenerateACI(layerData, dockerURL, outputDir, layerFile, curPwl, compress)
+	aciPath, manifest, err := common.GenerateACI(layerNumber, layerData, dockerURL, outputDir, layerFile, curPwl, compress)
 	if err != nil {
 		return "", nil, fmt.Errorf("error generating ACI: %v", err)
 	}

--- a/lib/backend/repository/repository.go
+++ b/lib/backend/repository/repository.go
@@ -1,352 +1,77 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package repository
 
 import (
-	"encoding/json"
-	"fmt"
-	"io"
-	"io/ioutil"
-	"net/http"
-	"os"
-	"path"
-	"strconv"
-	"strings"
-	"time"
-
 	"github.com/appc/docker2aci/lib/common"
 	"github.com/appc/docker2aci/lib/types"
-	"github.com/appc/docker2aci/lib/util"
 	"github.com/appc/spec/schema"
-	"github.com/coreos/ioprogress"
 )
 
-type RepoData struct {
-	Tokens    []string
-	Endpoints []string
-	Cookie    []string
-}
-
 type RepositoryBackend struct {
-	repoData *RepoData
-	username string
-	password string
+	repoData          *RepoData
+	username          string
+	password          string
+	insecure          bool
+	hostsV2Support    map[string]bool
+	hostsV2AuthTokens map[string]map[string]string
+	imageManifests    map[types.ParsedDockerURL]v2Manifest
 }
 
-func NewRepositoryBackend(username string, password string) *RepositoryBackend {
+func NewRepositoryBackend(username string, password string, insecure bool) *RepositoryBackend {
 	return &RepositoryBackend{
-		username: username,
-		password: password,
+		username:          username,
+		password:          password,
+		insecure:          insecure,
+		hostsV2Support:    make(map[string]bool),
+		hostsV2AuthTokens: make(map[string]map[string]string),
+		imageManifests:    make(map[types.ParsedDockerURL]v2Manifest),
 	}
 }
 
 func (rb *RepositoryBackend) GetImageInfo(url string) ([]string, *types.ParsedDockerURL, error) {
 	dockerURL := common.ParseDockerURL(url)
-	repoData, err := rb.getRepoData(dockerURL.IndexURL, dockerURL.ImageName)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error getting repository data: %v", err)
-	}
 
-	// TODO(iaguis) check more endpoints
-	appImageID, err := getImageIDFromTag(repoData.Endpoints[0], dockerURL.ImageName, dockerURL.Tag, repoData)
-	if err != nil {
-		return nil, nil, fmt.Errorf("error getting ImageID from tag %s: %v", dockerURL.Tag, err)
-	}
-
-	ancestry, err := getAncestry(appImageID, repoData.Endpoints[0], repoData)
-	if err != nil {
-		return nil, nil, err
-	}
-
-	rb.repoData = repoData
-
-	return ancestry, dockerURL, nil
-}
-
-func (rb *RepositoryBackend) BuildACI(layerID string, dockerURL *types.ParsedDockerURL, outputDir string, tmpBaseDir string, curPwl []string, compress bool) (string, *schema.ImageManifest, error) {
-	tmpDir, err := ioutil.TempDir(tmpBaseDir, "docker2aci-")
-	if err != nil {
-		return "", nil, fmt.Errorf("error creating dir: %v", err)
-	}
-	defer os.RemoveAll(tmpDir)
-
-	j, size, err := getJson(layerID, rb.repoData.Endpoints[0], rb.repoData)
-	if err != nil {
-		return "", nil, fmt.Errorf("error getting image json: %v", err)
-	}
-
-	layerData := types.DockerImageData{}
-	if err := json.Unmarshal(j, &layerData); err != nil {
-		return "", nil, fmt.Errorf("error unmarshaling layer data: %v", err)
-	}
-
-	layerFile, err := getLayer(layerID, rb.repoData.Endpoints[0], rb.repoData, size, tmpDir)
-	if err != nil {
-		return "", nil, fmt.Errorf("error getting the remote layer: %v", err)
-	}
-	defer layerFile.Close()
-
-	util.Debug("Generating layer ACI...")
-	aciPath, manifest, err := common.GenerateACI(layerData, dockerURL, outputDir, layerFile, curPwl, compress)
-	if err != nil {
-		return "", nil, fmt.Errorf("error generating ACI: %v", err)
-	}
-
-	return aciPath, manifest, nil
-}
-
-func (rb *RepositoryBackend) getRepoData(indexURL string, remote string) (*RepoData, error) {
-	client := &http.Client{}
-	repositoryURL := "https://" + path.Join(indexURL, "v1", "repositories", remote, "images")
-
-	req, err := http.NewRequest("GET", repositoryURL, nil)
-	if err != nil {
-		return nil, err
-	}
-
-	if rb.username != "" && rb.password != "" {
-		req.SetBasicAuth(rb.username, rb.password)
-	}
-
-	req.Header.Set("X-Docker-Token", "true")
-
-	res, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode != 200 {
-		return nil, fmt.Errorf("HTTP code: %d, URL: %s", res.StatusCode, req.URL)
-	}
-
-	var tokens []string
-	if res.Header.Get("X-Docker-Token") != "" {
-		tokens = res.Header["X-Docker-Token"]
-	}
-
-	var cookies []string
-	if res.Header.Get("Set-Cookie") != "" {
-		cookies = res.Header["Set-Cookie"]
-	}
-
-	var endpoints []string
-	if res.Header.Get("X-Docker-Endpoints") != "" {
-		endpoints = makeEndpointsList(res.Header["X-Docker-Endpoints"])
-	} else {
-		// Assume same endpoint
-		endpoints = append(endpoints, indexURL)
-	}
-
-	return &RepoData{
-		Endpoints: endpoints,
-		Tokens:    tokens,
-		Cookie:    cookies,
-	}, nil
-}
-
-func getImageIDFromTag(registry string, appName string, tag string, repoData *RepoData) (string, error) {
-	client := &http.Client{}
-	// we get all the tags instead of directly getting the imageID of the
-	// requested one (.../tags/TAG) because even though it's specified in the
-	// Docker API, some registries (e.g. Google Container Registry) don't
-	// implement it.
-	req, err := http.NewRequest("GET", "https://"+path.Join(registry, "repositories", appName, "tags"), nil)
-	if err != nil {
-		return "", fmt.Errorf("failed to get Image ID: %s, URL: %s", err, req.URL)
-	}
-
-	setAuthToken(req, repoData.Tokens)
-	setCookie(req, repoData.Cookie)
-	res, err := client.Do(req)
-	if err != nil {
-		return "", fmt.Errorf("failed to get Image ID: %s, URL: %s", err, req.URL)
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode != 200 {
-		return "", fmt.Errorf("HTTP code: %d. URL: %s", res.StatusCode, req.URL)
-	}
-
-	j, err := ioutil.ReadAll(res.Body)
-
-	if err != nil {
-		return "", err
-	}
-
-	var tags map[string]string
-
-	if err := json.Unmarshal(j, &tags); err != nil {
-		return "", fmt.Errorf("error unmarshaling: %v", err)
-	}
-
-	imageID, ok := tags[tag]
-	if !ok {
-		return "", fmt.Errorf("tag %s not found", tag)
-	}
-
-	return imageID, nil
-}
-
-func getAncestry(imgID, registry string, repoData *RepoData) ([]string, error) {
-	client := &http.Client{}
-	req, err := http.NewRequest("GET", "https://"+path.Join(registry, "images", imgID, "ancestry"), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	setAuthToken(req, repoData.Tokens)
-	setCookie(req, repoData.Cookie)
-	res, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode != 200 {
-		return nil, fmt.Errorf("HTTP code: %d. URL: %s", res.StatusCode, req.URL)
-	}
-
-	var ancestry []string
-
-	j, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return nil, fmt.Errorf("Failed to read downloaded json: %s (%s)", err, j)
-	}
-
-	if err := json.Unmarshal(j, &ancestry); err != nil {
-		return nil, fmt.Errorf("error unmarshaling: %v", err)
-	}
-
-	return ancestry, nil
-}
-
-func getJson(imgID, registry string, repoData *RepoData) ([]byte, int64, error) {
-	client := &http.Client{}
-	req, err := http.NewRequest("GET", "https://"+path.Join(registry, "images", imgID, "json"), nil)
-	if err != nil {
-		return nil, -1, err
-	}
-	setAuthToken(req, repoData.Tokens)
-	setCookie(req, repoData.Cookie)
-	res, err := client.Do(req)
-	if err != nil {
-		return nil, -1, err
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode != 200 {
-		return nil, -1, fmt.Errorf("HTTP code: %d, URL: %s", res.StatusCode, req.URL)
-	}
-
-	imageSize := int64(-1)
-
-	if hdr := res.Header.Get("X-Docker-Size"); hdr != "" {
-		imageSize, err = strconv.ParseInt(hdr, 10, 64)
+	var supportsV2, ok bool
+	if supportsV2, ok = rb.hostsV2Support[dockerURL.IndexURL]; !ok {
+		var err error
+		supportsV2, err = rb.supportsV2(dockerURL.IndexURL)
 		if err != nil {
-			return nil, -1, err
+			return nil, nil, err
 		}
+		rb.hostsV2Support[dockerURL.IndexURL] = supportsV2
 	}
 
-	b, err := ioutil.ReadAll(res.Body)
-	if err != nil {
-		return nil, -1, fmt.Errorf("failed to read downloaded json: %v (%s)", err, b)
-	}
-
-	return b, imageSize, nil
-}
-
-func getLayer(imgID, registry string, repoData *RepoData, imgSize int64, tmpDir string) (*os.File, error) {
-	client := &http.Client{}
-	req, err := http.NewRequest("GET", "https://"+path.Join(registry, "images", imgID, "layer"), nil)
-	if err != nil {
-		return nil, err
-	}
-
-	setAuthToken(req, repoData.Tokens)
-	setCookie(req, repoData.Cookie)
-
-	res, err := client.Do(req)
-	if err != nil {
-		return nil, err
-	}
-	defer res.Body.Close()
-
-	if res.StatusCode != 200 {
-		res.Body.Close()
-		return nil, fmt.Errorf("HTTP code: %d. URL: %s", res.StatusCode, req.URL)
-	}
-
-	// if we didn't receive the size via X-Docker-Size when we retrieved the
-	// layer's json, try Content-Length
-	if imgSize == -1 {
-		if hdr := res.Header.Get("Content-Length"); hdr != "" {
-			imgSize, err = strconv.ParseInt(hdr, 10, 64)
-			if err != nil {
-				return nil, err
-			}
-		}
-	}
-
-	prefix := "Downloading " + imgID[:12]
-	fmtBytesSize := 18
-	barSize := int64(80 - len(prefix) - fmtBytesSize)
-	bar := ioprogress.DrawTextFormatBarForW(barSize, os.Stderr)
-	fmtfunc := func(progress, total int64) string {
-		return fmt.Sprintf(
-			"%s: %s %s",
-			prefix,
-			bar(progress, total),
-			ioprogress.DrawTextFormatBytes(progress, total),
-		)
-	}
-
-	progressReader := &ioprogress.Reader{
-		Reader:       res.Body,
-		Size:         imgSize,
-		DrawFunc:     ioprogress.DrawTerminalf(os.Stderr, fmtfunc),
-		DrawInterval: 500 * time.Millisecond,
-	}
-
-	layerFile, err := ioutil.TempFile(tmpDir, "dockerlayer-")
-	if err != nil {
-		return nil, err
-	}
-
-	_, err = io.Copy(layerFile, progressReader)
-	if err != nil {
-		return nil, err
-	}
-
-	if err := layerFile.Sync(); err != nil {
-		return nil, err
-	}
-
-	return layerFile, nil
-}
-
-func setAuthToken(req *http.Request, token []string) {
-	if req.Header.Get("Authorization") == "" {
-		req.Header.Set("Authorization", "Token "+strings.Join(token, ","))
+	if supportsV2 {
+		return rb.getImageInfoV2(dockerURL)
+	} else {
+		return rb.getImageInfoV1(dockerURL)
 	}
 }
 
-func setCookie(req *http.Request, cookie []string) {
-	if req.Header.Get("Cookie") == "" {
-		req.Header.Set("Cookie", strings.Join(cookie, ""))
+func (rb *RepositoryBackend) BuildACI(layerNumber int, layerID string, dockerURL *types.ParsedDockerURL, outputDir string, tmpBaseDir string, curPwl []string, compress bool) (string, *schema.ImageManifest, error) {
+	if rb.hostsV2Support[dockerURL.IndexURL] {
+		return rb.buildACIV2(layerNumber, layerID, dockerURL, outputDir, tmpBaseDir, curPwl, compress)
+	} else {
+		return rb.buildACIV1(layerNumber, layerID, dockerURL, outputDir, tmpBaseDir, curPwl, compress)
 	}
 }
 
-func makeEndpointsList(headers []string) []string {
-	var endpoints []string
-
-	for _, ep := range headers {
-		endpointsList := strings.Split(ep, ",")
-		for _, endpointEl := range endpointsList {
-			endpoints = append(
-				endpoints,
-				// TODO(iaguis) discover if httpsOrHTTP
-				path.Join(strings.TrimSpace(endpointEl), "v1"))
-		}
+func (rb *RepositoryBackend) protocol() string {
+	if rb.insecure {
+		return "http://"
+	} else {
+		return "https://"
 	}
-
-	return endpoints
 }

--- a/lib/backend/repository/repository1.go
+++ b/lib/backend/repository/repository1.go
@@ -1,0 +1,350 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package repository
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/appc/docker2aci/lib/common"
+	"github.com/appc/docker2aci/lib/types"
+	"github.com/appc/docker2aci/lib/util"
+	"github.com/appc/spec/schema"
+	"github.com/coreos/ioprogress"
+)
+
+type RepoData struct {
+	Tokens    []string
+	Endpoints []string
+	Cookie    []string
+}
+
+func (rb *RepositoryBackend) getImageInfoV1(dockerURL *types.ParsedDockerURL) ([]string, *types.ParsedDockerURL, error) {
+	repoData, err := rb.getRepoDataV1(dockerURL.IndexURL, dockerURL.ImageName)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error getting repository data: %v", err)
+	}
+
+	// TODO(iaguis) check more endpoints
+	appImageID, err := rb.getImageIDFromTagV1(repoData.Endpoints[0], dockerURL.ImageName, dockerURL.Tag, repoData)
+	if err != nil {
+		return nil, nil, fmt.Errorf("error getting ImageID from tag %s: %v", dockerURL.Tag, err)
+	}
+
+	ancestry, err := rb.getAncestryV1(appImageID, repoData.Endpoints[0], repoData)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	rb.repoData = repoData
+
+	return ancestry, dockerURL, nil
+}
+
+func (rb *RepositoryBackend) buildACIV1(layerNumber int, layerID string, dockerURL *types.ParsedDockerURL, outputDir string, tmpBaseDir string, curPwl []string, compress bool) (string, *schema.ImageManifest, error) {
+	tmpDir, err := ioutil.TempDir(tmpBaseDir, "docker2aci-")
+	if err != nil {
+		return "", nil, fmt.Errorf("error creating dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	j, size, err := rb.getJsonV1(layerID, rb.repoData.Endpoints[0], rb.repoData)
+	if err != nil {
+		return "", nil, fmt.Errorf("error getting image json: %v", err)
+	}
+
+	layerData := types.DockerImageData{}
+	if err := json.Unmarshal(j, &layerData); err != nil {
+		return "", nil, fmt.Errorf("error unmarshaling layer data: %v", err)
+	}
+
+	layerFile, err := rb.getLayerV1(layerID, rb.repoData.Endpoints[0], rb.repoData, size, tmpDir)
+	if err != nil {
+		return "", nil, fmt.Errorf("error getting the remote layer: %v", err)
+	}
+	defer layerFile.Close()
+
+	util.Debug("Generating layer ACI...")
+	aciPath, manifest, err := common.GenerateACI(layerNumber, layerData, dockerURL, outputDir, layerFile, curPwl, compress)
+	if err != nil {
+		return "", nil, fmt.Errorf("error generating ACI: %v", err)
+	}
+
+	return aciPath, manifest, nil
+}
+
+func (rb *RepositoryBackend) getRepoDataV1(indexURL string, remote string) (*RepoData, error) {
+	client := &http.Client{}
+	repositoryURL := rb.protocol() + path.Join(indexURL, "v1", "repositories", remote, "images")
+
+	req, err := http.NewRequest("GET", repositoryURL, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	if rb.username != "" && rb.password != "" {
+		req.SetBasicAuth(rb.username, rb.password)
+	}
+
+	req.Header.Set("X-Docker-Token", "true")
+
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf("HTTP code: %d, URL: %s", res.StatusCode, req.URL)
+	}
+
+	var tokens []string
+	if res.Header.Get("X-Docker-Token") != "" {
+		tokens = res.Header["X-Docker-Token"]
+	}
+
+	var cookies []string
+	if res.Header.Get("Set-Cookie") != "" {
+		cookies = res.Header["Set-Cookie"]
+	}
+
+	var endpoints []string
+	if res.Header.Get("X-Docker-Endpoints") != "" {
+		endpoints = makeEndpointsListV1(res.Header["X-Docker-Endpoints"])
+	} else {
+		// Assume same endpoint
+		endpoints = append(endpoints, indexURL)
+	}
+
+	return &RepoData{
+		Endpoints: endpoints,
+		Tokens:    tokens,
+		Cookie:    cookies,
+	}, nil
+}
+
+func (rb *RepositoryBackend) getImageIDFromTagV1(registry string, appName string, tag string, repoData *RepoData) (string, error) {
+	client := &http.Client{}
+	// we get all the tags instead of directly getting the imageID of the
+	// requested one (.../tags/TAG) because even though it's specified in the
+	// Docker API, some registries (e.g. Google Container Registry) don't
+	// implement it.
+	req, err := http.NewRequest("GET", rb.protocol()+path.Join(registry, "repositories", appName, "tags"), nil)
+	if err != nil {
+		return "", fmt.Errorf("failed to get Image ID: %s, URL: %s", err, req.URL)
+	}
+
+	setAuthTokenV1(req, repoData.Tokens)
+	setCookieV1(req, repoData.Cookie)
+	res, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("failed to get Image ID: %s, URL: %s", err, req.URL)
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != 200 {
+		return "", fmt.Errorf("HTTP code: %d. URL: %s", res.StatusCode, req.URL)
+	}
+
+	j, err := ioutil.ReadAll(res.Body)
+
+	if err != nil {
+		return "", err
+	}
+
+	var tags map[string]string
+
+	if err := json.Unmarshal(j, &tags); err != nil {
+		return "", fmt.Errorf("error unmarshaling: %v", err)
+	}
+
+	imageID, ok := tags[tag]
+	if !ok {
+		return "", fmt.Errorf("tag %s not found", tag)
+	}
+
+	return imageID, nil
+}
+
+func (rb *RepositoryBackend) getAncestryV1(imgID, registry string, repoData *RepoData) ([]string, error) {
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", rb.protocol()+path.Join(registry, "images", imgID, "ancestry"), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	setAuthTokenV1(req, repoData.Tokens)
+	setCookieV1(req, repoData.Cookie)
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf("HTTP code: %d. URL: %s", res.StatusCode, req.URL)
+	}
+
+	var ancestry []string
+
+	j, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, fmt.Errorf("Failed to read downloaded json: %s (%s)", err, j)
+	}
+
+	if err := json.Unmarshal(j, &ancestry); err != nil {
+		return nil, fmt.Errorf("error unmarshaling: %v", err)
+	}
+
+	return ancestry, nil
+}
+
+func (rb *RepositoryBackend) getJsonV1(imgID, registry string, repoData *RepoData) ([]byte, int64, error) {
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", rb.protocol()+path.Join(registry, "images", imgID, "json"), nil)
+	if err != nil {
+		return nil, -1, err
+	}
+	setAuthTokenV1(req, repoData.Tokens)
+	setCookieV1(req, repoData.Cookie)
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, -1, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != 200 {
+		return nil, -1, fmt.Errorf("HTTP code: %d, URL: %s", res.StatusCode, req.URL)
+	}
+
+	imageSize := int64(-1)
+
+	if hdr := res.Header.Get("X-Docker-Size"); hdr != "" {
+		imageSize, err = strconv.ParseInt(hdr, 10, 64)
+		if err != nil {
+			return nil, -1, err
+		}
+	}
+
+	b, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, -1, fmt.Errorf("failed to read downloaded json: %v (%s)", err, b)
+	}
+
+	return b, imageSize, nil
+}
+
+func (rb *RepositoryBackend) getLayerV1(imgID, registry string, repoData *RepoData, imgSize int64, tmpDir string) (*os.File, error) {
+	client := &http.Client{}
+	req, err := http.NewRequest("GET", rb.protocol()+path.Join(registry, "images", imgID, "layer"), nil)
+	if err != nil {
+		return nil, err
+	}
+
+	setAuthTokenV1(req, repoData.Tokens)
+	setCookieV1(req, repoData.Cookie)
+
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != 200 {
+		res.Body.Close()
+		return nil, fmt.Errorf("HTTP code: %d. URL: %s", res.StatusCode, req.URL)
+	}
+
+	// if we didn't receive the size via X-Docker-Size when we retrieved the
+	// layer's json, try Content-Length
+	if imgSize == -1 {
+		if hdr := res.Header.Get("Content-Length"); hdr != "" {
+			imgSize, err = strconv.ParseInt(hdr, 10, 64)
+			if err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	prefix := "Downloading " + imgID[:12]
+	fmtBytesSize := 18
+	barSize := int64(80 - len(prefix) - fmtBytesSize)
+	bar := ioprogress.DrawTextFormatBarForW(barSize, os.Stderr)
+	fmtfunc := func(progress, total int64) string {
+		return fmt.Sprintf(
+			"%s: %s %s",
+			prefix,
+			bar(progress, total),
+			ioprogress.DrawTextFormatBytes(progress, total),
+		)
+	}
+
+	progressReader := &ioprogress.Reader{
+		Reader:       res.Body,
+		Size:         imgSize,
+		DrawFunc:     ioprogress.DrawTerminalf(os.Stderr, fmtfunc),
+		DrawInterval: 500 * time.Millisecond,
+	}
+
+	layerFile, err := ioutil.TempFile(tmpDir, "dockerlayer-")
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = io.Copy(layerFile, progressReader)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := layerFile.Sync(); err != nil {
+		return nil, err
+	}
+
+	return layerFile, nil
+}
+
+func setAuthTokenV1(req *http.Request, token []string) {
+	if req.Header.Get("Authorization") == "" {
+		req.Header.Set("Authorization", "Token "+strings.Join(token, ","))
+	}
+}
+
+func setCookieV1(req *http.Request, cookie []string) {
+	if req.Header.Get("Cookie") == "" {
+		req.Header.Set("Cookie", strings.Join(cookie, ""))
+	}
+}
+
+func makeEndpointsListV1(headers []string) []string {
+	var endpoints []string
+
+	for _, ep := range headers {
+		endpointsList := strings.Split(ep, ",")
+		for _, endpointEl := range endpointsList {
+			endpoints = append(
+				endpoints,
+				path.Join(strings.TrimSpace(endpointEl), "v1"))
+		}
+	}
+
+	return endpoints
+}

--- a/lib/backend/repository/repository2.go
+++ b/lib/backend/repository/repository2.go
@@ -1,0 +1,370 @@
+// Copyright 2015 CoreOS, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package repository
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"path"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/appc/docker2aci/lib/common"
+	"github.com/appc/docker2aci/lib/types"
+	"github.com/appc/docker2aci/lib/util"
+	"github.com/appc/spec/schema"
+	"github.com/coreos/ioprogress"
+)
+
+const (
+	defaultIndexURL = "registry-1.docker.io"
+)
+
+type v2Manifest struct {
+	Name     string `json:"name"`
+	Tag      string `json:"tag"`
+	FSLayers []struct {
+		BlobSum string `json:"blobSum"`
+	} `json:"fsLayers"`
+	History []struct {
+		V1Compatibility string `json:"v1Compatibility"`
+	} `json:"history"`
+	Signature []byte `json:"signature"`
+}
+
+func (rb *RepositoryBackend) supportsV2(indexURL string) (bool, error) {
+	url := rb.protocol() + path.Join(indexURL, "v2")
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return false, err
+	}
+
+	if rb.username != "" && rb.password != "" {
+		req.SetBasicAuth(rb.username, rb.password)
+	}
+
+	client := &http.Client{}
+	res, err := client.Do(req)
+	if err != nil {
+		return false, err
+	}
+	defer res.Body.Close()
+
+	switch res.StatusCode {
+	case http.StatusOK, http.StatusUnauthorized:
+		if res.Header.Get("Docker-Distribution-API-Version") == "registry/2.0" {
+			return true, nil
+		}
+		return false, nil
+	case http.StatusNotFound:
+		return false, nil
+	default:
+		return false, fmt.Errorf("unexpected http code: %d, URL: %s", res.StatusCode, req.URL)
+	}
+}
+
+func (rb *RepositoryBackend) getImageInfoV2(dockerURL *types.ParsedDockerURL) ([]string, *types.ParsedDockerURL, error) {
+	manifest, layers, err := rb.getManifestV2(dockerURL)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	rb.imageManifests[*dockerURL] = *manifest
+
+	return layers, dockerURL, nil
+}
+
+func (rb *RepositoryBackend) buildACIV2(layerNumber int, layerID string, dockerURL *types.ParsedDockerURL, outputDir string, tmpBaseDir string, curPwl []string, compress bool) (string, *schema.ImageManifest, error) {
+	manifest := rb.imageManifests[*dockerURL]
+
+	layerIndex, err := getLayerIndex(layerID, manifest)
+	if err != nil {
+		return "", nil, err
+	}
+
+	if len(manifest.History) <= layerIndex {
+		return "", nil, fmt.Errorf("history not found for layer %s", layerID)
+	}
+
+	layerData := types.DockerImageData{}
+	if err := json.Unmarshal([]byte(manifest.History[layerIndex].V1Compatibility), &layerData); err != nil {
+		return "", nil, fmt.Errorf("error unmarshaling layer data: %v", err)
+	}
+
+	tmpDir, err := ioutil.TempDir(tmpBaseDir, "docker2aci-")
+	if err != nil {
+		return "", nil, fmt.Errorf("error creating dir: %v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+
+	layerFile, err := rb.getLayerV2(layerID, dockerURL, tmpDir)
+	if err != nil {
+		return "", nil, fmt.Errorf("error getting the remote layer: %v", err)
+	}
+	defer layerFile.Close()
+
+	util.Debug("Generating layer ACI...")
+	aciPath, aciManifest, err := common.GenerateACI(layerNumber, layerData, dockerURL, outputDir, layerFile, curPwl, compress)
+	if err != nil {
+		return "", nil, fmt.Errorf("error generating ACI: %v", err)
+	}
+
+	return aciPath, aciManifest, nil
+}
+
+func (rb *RepositoryBackend) getManifestV2(dockerURL *types.ParsedDockerURL) (*v2Manifest, []string, error) {
+	url := rb.protocol() + path.Join(dockerURL.IndexURL, "v2", dockerURL.ImageName, "manifests", dockerURL.Tag)
+
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if rb.username != "" && rb.password != "" {
+		req.SetBasicAuth(rb.username, rb.password)
+	}
+
+	res, err := rb.makeRequest(req, dockerURL.ImageName)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != http.StatusOK {
+		return nil, nil, fmt.Errorf("unexpected http code: %d, URL: %s", res.StatusCode, req.URL)
+	}
+
+	manblob, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	manifest := &v2Manifest{}
+
+	err = json.Unmarshal(manblob, manifest)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	if manifest.Name != dockerURL.ImageName {
+		return nil, nil, fmt.Errorf("name doesn't match what was requested, expected: %s, downloaded: %s", dockerURL.ImageName, manifest.Name)
+	}
+
+	if manifest.Tag != dockerURL.Tag {
+		return nil, nil, fmt.Errorf("tag doesn't match what was requested, expected: %s, downloaded: %s", dockerURL.Tag, manifest.Tag)
+	}
+
+	//TODO: verify signature here
+
+	layers := make([]string, len(manifest.FSLayers))
+
+	for i, layer := range manifest.FSLayers {
+		layers[i] = layer.BlobSum
+	}
+
+	return manifest, layers, nil
+}
+
+func getLayerIndex(layerID string, manifest v2Manifest) (int, error) {
+	for i, layer := range manifest.FSLayers {
+		if layer.BlobSum == layerID {
+			return i, nil
+		}
+	}
+	return -1, fmt.Errorf("layer not found in manifest: %s", layerID)
+}
+
+func (rb *RepositoryBackend) getLayerV2(layerID string, dockerURL *types.ParsedDockerURL, tmpDir string) (*os.File, error) {
+	url := rb.protocol() + path.Join(dockerURL.IndexURL, "v2", dockerURL.ImageName, "blobs", layerID)
+	req, err := http.NewRequest("GET", url, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	res, err := rb.makeRequest(req, dockerURL.ImageName)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	if res.StatusCode != 200 {
+		return nil, fmt.Errorf("HTTP code: %d. URL: %s", res.StatusCode, req.URL)
+	}
+
+	var in io.Reader
+	in = res.Body
+
+	if hdr := res.Header.Get("Content-Length"); hdr != "" {
+		imgSize, err := strconv.ParseInt(hdr, 10, 64)
+		if err != nil {
+			return nil, err
+		}
+
+		prefix := "Downloading " + layerID[:18]
+		fmtBytesSize := 18
+		barSize := int64(80 - len(prefix) - fmtBytesSize)
+		bar := ioprogress.DrawTextFormatBarForW(barSize, os.Stderr)
+		fmtfunc := func(progress, total int64) string {
+			return fmt.Sprintf(
+				"%s: %s %s",
+				prefix,
+				bar(progress, total),
+				ioprogress.DrawTextFormatBytes(progress, total),
+			)
+		}
+		in = &ioprogress.Reader{
+			Reader:       res.Body,
+			Size:         imgSize,
+			DrawFunc:     ioprogress.DrawTerminalf(os.Stderr, fmtfunc),
+			DrawInterval: 500 * time.Millisecond,
+		}
+	}
+
+	layerFile, err := ioutil.TempFile(tmpDir, "dockerlayer-")
+	if err != nil {
+		return nil, err
+	}
+
+	_, err = io.Copy(layerFile, in)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := layerFile.Sync(); err != nil {
+		return nil, err
+	}
+
+	return layerFile, nil
+}
+
+func (rb *RepositoryBackend) makeRequest(req *http.Request, repo string) (*http.Response, error) {
+	setBearerHeader := false
+	hostAuthTokens, ok := rb.hostsV2AuthTokens[req.URL.Host]
+	if ok {
+		authToken, ok := hostAuthTokens[repo]
+		if ok {
+			req.Header.Set("Authorization", "Bearer "+authToken)
+			setBearerHeader = true
+		}
+	}
+
+	client := &http.Client{}
+	res, err := client.Do(req)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode == http.StatusUnauthorized && setBearerHeader {
+		return res, err
+	}
+
+	hdr := res.Header.Get("www-authenticate")
+	if res.StatusCode != http.StatusUnauthorized || hdr == "" {
+		return res, err
+	}
+
+	tokens := strings.Split(hdr, " ")
+	if len(tokens) != 2 || strings.ToLower(tokens[0]) != "bearer" {
+		return res, err
+	}
+
+	res.Body.Close()
+
+	tokens = strings.Split(tokens[1], ",")
+
+	var realm, service, scope string
+	for _, token := range tokens {
+		if strings.HasPrefix(token, "realm") {
+			realm = strings.Trim(token[len("realm="):], "\"")
+		}
+		if strings.HasPrefix(token, "service") {
+			service = strings.Trim(token[len("service="):], "\"")
+		}
+		if strings.HasPrefix(token, "scope") {
+			scope = strings.Trim(token[len("scope="):], "\"")
+		}
+	}
+
+	if realm == "" {
+		return nil, fmt.Errorf("missing realm in bearer auth challenge")
+	}
+	if service == "" {
+		return nil, fmt.Errorf("missing service in bearer auth challenge")
+	}
+	// The scope can be empty if we're not getting a token for a specific repo
+	if scope == "" && repo != "" {
+		return nil, fmt.Errorf("missing scope in bearer auth challenge")
+	}
+
+	authReq, err := http.NewRequest("GET", realm, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	getParams := authReq.URL.Query()
+	getParams.Add("service", service)
+	if scope != "" {
+		getParams.Add("scope", scope)
+	}
+	authReq.URL.RawQuery = getParams.Encode()
+
+	if rb.username != "" && rb.password != "" {
+		authReq.SetBasicAuth(rb.username, rb.password)
+	}
+
+	res, err = client.Do(authReq)
+	if err != nil {
+		return nil, err
+	}
+	defer res.Body.Close()
+
+	switch res.StatusCode {
+	case http.StatusUnauthorized:
+		return nil, fmt.Errorf("unable to retrieve auth token: 401 unauthorized")
+	case http.StatusOK:
+		break
+	default:
+		return nil, fmt.Errorf("unexpected http code: %d, URL: %s", res.StatusCode, authReq.URL)
+	}
+
+	tokenBlob, err := ioutil.ReadAll(res.Body)
+	if err != nil {
+		return nil, err
+	}
+
+	tokenStruct := struct {
+		Token string `json:"token"`
+	}{}
+
+	err = json.Unmarshal(tokenBlob, &tokenStruct)
+	if err != nil {
+		return nil, err
+	}
+
+	hostAuthTokens, ok = rb.hostsV2AuthTokens[req.URL.Host]
+	if !ok {
+		hostAuthTokens = make(map[string]string)
+		rb.hostsV2AuthTokens[req.URL.Host] = hostAuthTokens
+	}
+
+	hostAuthTokens[repo] = tokenStruct.Token
+
+	return rb.makeRequest(req, repo)
+}

--- a/lib/common/docker_functions.go
+++ b/lib/common/docker_functions.go
@@ -28,7 +28,6 @@ import (
 )
 
 const (
-	defaultIndex      = "index.docker.io"
 	dockercfgFileName = ".dockercfg"
 )
 
@@ -39,8 +38,9 @@ func SplitReposName(reposName string) (string, string) {
 	if len(nameParts) == 1 || (!strings.Contains(nameParts[0], ".") &&
 		!strings.Contains(nameParts[0], ":") && nameParts[0] != "localhost") {
 		// This is a Docker Index repos (ex: samalba/hipache or ubuntu)
-		// 'docker.io'
-		indexName = defaultIndex
+		// The URL for the index is different depending on the version of the
+		// API used to fetch it, so it cannot be inferred here.
+		indexName = ""
 		remoteName = reposName
 	} else {
 		indexName = nameParts[0]

--- a/lib/docker2aci.go
+++ b/lib/docker2aci.go
@@ -39,7 +39,7 @@ import (
 
 type Docker2ACIBackend interface {
 	GetImageInfo(dockerUrl string) ([]string, *types.ParsedDockerURL, error)
-	BuildACI(layerID string, dockerURL *types.ParsedDockerURL, outputDir string, tmpBaseDir string, curPWl []string, compress bool) (string, *schema.ImageManifest, error)
+	BuildACI(layerNumber int, layerID string, dockerURL *types.ParsedDockerURL, outputDir string, tmpBaseDir string, curPWl []string, compress bool) (string, *schema.ImageManifest, error)
 }
 
 // Convert generates ACI images from docker registry URLs.
@@ -56,8 +56,8 @@ type Docker2ACIBackend interface {
 // temporary directory if tmpDir is "".
 // username and password can be passed if the image needs authentication.
 // It returns the list of generated ACI paths.
-func Convert(dockerURL string, squash bool, outputDir string, tmpDir string, username string, password string) ([]string, error) {
-	repositoryBackend := repository.NewRepositoryBackend(username, password)
+func Convert(dockerURL string, squash bool, outputDir string, tmpDir string, username string, password string, insecure bool) ([]string, error) {
+	repositoryBackend := repository.NewRepositoryBackend(username, password, insecure)
 	return convertReal(repositoryBackend, dockerURL, squash, outputDir, tmpDir)
 }
 
@@ -123,7 +123,7 @@ func convertReal(backend Docker2ACIBackend, dockerURL string, squash bool, outpu
 		layerID := ancestry[i]
 
 		// only compress individual layers if we're not squashing
-		aciPath, manifest, err := backend.BuildACI(layerID, parsedDockerURL, layersOutputDir, tmpDir, curPwl, !squash)
+		aciPath, manifest, err := backend.BuildACI(i, layerID, parsedDockerURL, layersOutputDir, tmpDir, curPwl, !squash)
 		if err != nil {
 			return nil, fmt.Errorf("error building layer: %v", err)
 		}

--- a/main.go
+++ b/main.go
@@ -32,9 +32,10 @@ var (
 	flagNoSquash = flag.Bool("nosquash", false, "Don't squash layers and output every layer as ACI")
 	flagImage    = flag.String("image", "", "When converting a local file, it selects a particular image to convert. Format: IMAGE_NAME[:TAG]")
 	flagDebug    = flag.Bool("debug", false, "Enables debug messages")
+	flagInsecure = flag.Bool("insecure", false, "Uses unencrypted connections when fetching images")
 )
 
-func runDocker2ACI(arg string, flagNoSquash bool, flagImage string, flagDebug bool) error {
+func runDocker2ACI(arg string, flagNoSquash bool, flagImage string, flagDebug bool, flagInsecure bool) error {
 	if flagDebug {
 		util.InitDebug()
 	}
@@ -60,7 +61,7 @@ func runDocker2ACI(arg string, flagNoSquash bool, flagImage string, flagDebug bo
 			return fmt.Errorf("error reading .dockercfg file: %v", err)
 		}
 
-		aciLayerPaths, err = docker2aci.Convert(dockerURL, squash, ".", os.TempDir(), username, password)
+		aciLayerPaths, err = docker2aci.Convert(dockerURL, squash, ".", os.TempDir(), username, password, flagInsecure)
 	} else {
 		aciLayerPaths, err = docker2aci.ConvertFile(flagImage, arg, squash, ".", os.TempDir())
 	}
@@ -156,7 +157,7 @@ func main() {
 		return
 	}
 
-	if err := runDocker2ACI(args[0], *flagNoSquash, *flagImage, *flagDebug); err != nil {
+	if err := runDocker2ACI(args[0], *flagNoSquash, *flagImage, *flagDebug, *flagInsecure); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
Will detect when fetching an image if the V2 API is supported, and fall
back to the V1 API if it is not. Auth currently unsupported.

Partially addresses https://github.com/appc/docker2aci/issues/46 and https://github.com/coreos/rkt/issues/1583.