### PR TITLE
handle hard links and whiteouts correctly

### DIFF
--- a/tests/test-basic/check.sh
+++ b/tests/test-basic/check.sh
@@ -1,13 +1,15 @@
 #!/bin/sh
 set -e
+set -x
+
 grep -q file1 file1
 grep -q file1 file2
 grep -q file3 file3
 grep -q file4 file4
-if [ "$rendered" != "true" ] ; then
-	test -e file1
-	test -e file2
-	test $(stat -c %i file1) -eq $(stat -c %i file2)
-	test $(stat -c %i file3) -ne $(stat -c %i file4)
+if [ "$CHECK" != "rkt-rendered" ] ; then
+	# Skip this test because of:
+	# https://github.com/coreos/rkt/issues/1774
+	test $(ls -i file1 |awk '{print $1}') -eq $(ls -i file2 |awk '{print $1}')
+	test $(ls -i file3 |awk '{print $1}') -ne $(ls -i file4 |awk '{print $1}')
 fi
 echo "SUCCESS"

--- a/tests/test-whiteouts/Dockerfile
+++ b/tests/test-whiteouts/Dockerfile
@@ -1,0 +1,19 @@
+FROM busybox
+COPY check.sh /
+
+RUN mount
+
+RUN echo layer1 > layer1-file1 ; ln layer1-file1 layer1-file2 ; ln layer1-file1 layer1-file3
+RUN echo layer2 > layer2-file1 ; ln layer2-file1 layer2-file2 ; ln layer2-file1 layer2-file3
+RUN echo layer3 > layer3-file1 ; ln layer3-file1 layer3-file2 ; ln layer3-file1 layer3-file3
+RUN rm -f layer1-file1 layer2-file2 layer3-file3
+
+RUN mount
+
+RUN echo OLD > layer4-file1 ; ln layer4-file1 layer4-file2 ; ln layer4-file1 layer4-file3
+RUN echo NEW > layer4-file1 ; ln -f layer4-file1 layer4-file2 ; ln -f layer4-file1 layer4-file3 ; echo foo > foo
+
+RUN echo line1 >  layer5-file1 ; ln layer5-file1 layer5-file2 ; ln layer5-file1 layer5-file3
+RUN echo line2 >> layer5-file1
+
+CMD /check.sh 2>&1

--- a/tests/test-whiteouts/check.sh
+++ b/tests/test-whiteouts/check.sh
@@ -1,0 +1,44 @@
+#!/bin/sh
+set -e
+set -x
+
+test ! -e layer1-file1
+test   -e layer1-file2
+test   -e layer1-file3
+
+test   -e layer2-file1
+test ! -e layer2-file2
+test   -e layer2-file3
+
+test   -e layer3-file1
+test   -e layer3-file2
+test ! -e layer3-file3
+
+grep -q layer1 layer1-file2
+grep -q layer1 layer1-file3
+
+grep -q layer2 layer2-file1
+grep -q layer2 layer2-file3
+
+grep -q layer3 layer3-file1
+grep -q layer3 layer3-file2
+
+grep -q NEW layer4-file1
+grep -q NEW layer4-file2
+grep -q NEW layer4-file3
+
+grep -q line1 layer5-file1
+grep -q line1 layer5-file2
+grep -q line1 layer5-file3
+
+# # Docker with AUFS storage backend does not handle this test correctly and
+# # Semaphore uses AUFS
+if [ "$DOCKER_STORAGE_BACKEND" != aufs ] ; then
+	grep -q line2 layer5-file1
+	grep -q line2 layer5-file2
+	grep -q line2 layer5-file3
+	cmp layer5-file1 layer5-file2
+	cmp layer5-file1 layer5-file3
+fi
+
+echo "SUCCESS"


### PR DESCRIPTION
Hard links and whiteout were not handled correctly in this scenario:
- The first Docker layer contains:
  - file A
  - file B hard link to file A
- The second Docker layer contains:
  - whiteout file A

Then, the squashed ACI previously generated by docker2aci contained:
  - file B dangling hard link to file A

Hence the bug.

This patch changes:
- the converting algorithm lib/common/common.go:writeACI() to generate:
  - First docker layer
    - .hidden.docker2aci.sha512-xxx (hash of the layer and file name)
    - file A hard link to .hidden.docker2aci.sha512-xxx
    - file B hard link to .hidden.docker2aci.sha512-xxx
  - Second docker layer
    - whiteout file A
- the squashing algorithm lib/docker2aci.go:SquashLayers() to have two
  passes:
  - Pass one: build an in-memory map of hard links and whiteouts
  - Pass two: remove white-out and .hidden.docker2aci.sha512-xxx files

I tested the following images from https://github.com/coreos/rkt/issues/1653:
- docker://albanc/busybox-hardlinks
- docker://zopyx/xmldirector-plone

TODO:
- not optimized if there are no hard links
- semantic changes on --nosquash

Fixes https://github.com/appc/docker2aci/issues/98