### PR TITLE
lib: don't close reader inside ReadStream

### DIFF
--- a/lib/conversion_store.go
+++ b/lib/conversion_store.go
@@ -98,9 +98,8 @@ func (ms *ConversionStore) ReadStream(key string) (io.ReadCloser, error) {
 	if err != nil {
 		return nil, err
 	}
-	defer tr.Close()
 
-	return ioutil.NopCloser(tr), nil
+	return tr, nil
 }
 
 func (ms *ConversionStore) ResolveKey(key string) (string, error) {


### PR DESCRIPTION
When aci.NewCompressedReader was changed to return a ReadCloser, we
changed the code in ReadStream to close it and then wrapped it with a
NopCloser. That was obviously wrong although it didn't seem to have any
effect.

Let's return the ReadCloser directly instead.