### PR TITLE
docker2aci: separate "http" and "accept any certificate" flags

### DIFF
--- a/lib/backend/repository/repository.go
+++ b/lib/backend/repository/repository.go
@@ -20,23 +20,25 @@ import (
 )
 
 type RepositoryBackend struct {
-	repoData          *RepoData
-	username          string
-	password          string
-	insecure          bool
-	hostsV2Support    map[string]bool
-	hostsV2AuthTokens map[string]map[string]string
-	imageManifests    map[types.ParsedDockerURL]v2Manifest
+	repoData           *RepoData
+	username           string
+	password           string
+	insecureSkipVerify bool
+	insecureRegistry   bool
+	hostsV2Support     map[string]bool
+	hostsV2AuthTokens  map[string]map[string]string
+	imageManifests     map[types.ParsedDockerURL]v2Manifest
 }
 
-func NewRepositoryBackend(username string, password string, insecure bool) *RepositoryBackend {
+func NewRepositoryBackend(username string, password string, insecureSkipVerify bool, insecureRegistry bool) *RepositoryBackend {
 	return &RepositoryBackend{
-		username:          username,
-		password:          password,
-		insecure:          insecure,
-		hostsV2Support:    make(map[string]bool),
-		hostsV2AuthTokens: make(map[string]map[string]string),
-		imageManifests:    make(map[types.ParsedDockerURL]v2Manifest),
+		username:           username,
+		password:           password,
+		insecureSkipVerify: insecureSkipVerify,
+		insecureRegistry:   insecureRegistry,
+		hostsV2Support:     make(map[string]bool),
+		hostsV2AuthTokens:  make(map[string]map[string]string),
+		imageManifests:     make(map[types.ParsedDockerURL]v2Manifest),
 	}
 }
 
@@ -69,7 +71,7 @@ func (rb *RepositoryBackend) BuildACI(layerNumber int, layerID string, dockerURL
 }
 
 func (rb *RepositoryBackend) protocol() string {
-	if rb.insecure {
+	if rb.insecureRegistry {
 		return "http://"
 	} else {
 		return "https://"

--- a/lib/docker2aci.go
+++ b/lib/docker2aci.go
@@ -56,8 +56,8 @@ type Docker2ACIBackend interface {
 // temporary directory if tmpDir is "".
 // username and password can be passed if the image needs authentication.
 // It returns the list of generated ACI paths.
-func Convert(dockerURL string, squash bool, outputDir string, tmpDir string, username string, password string, insecure bool) ([]string, error) {
-	repositoryBackend := repository.NewRepositoryBackend(username, password, insecure)
+func Convert(dockerURL string, squash bool, outputDir string, tmpDir string, username string, password string, insecureSkipVerify bool, insecureRegistry bool) ([]string, error) {
+	repositoryBackend := repository.NewRepositoryBackend(username, password, insecureSkipVerify, insecureRegistry)
 	return convertReal(repositoryBackend, dockerURL, squash, outputDir, tmpDir)
 }
 

--- a/main.go
+++ b/main.go
@@ -29,13 +29,14 @@ import (
 )
 
 var (
-	flagNoSquash = flag.Bool("nosquash", false, "Don't squash layers and output every layer as ACI")
-	flagImage    = flag.String("image", "", "When converting a local file, it selects a particular image to convert. Format: IMAGE_NAME[:TAG]")
-	flagDebug    = flag.Bool("debug", false, "Enables debug messages")
-	flagInsecure = flag.Bool("insecure", false, "Uses unencrypted connections when fetching images")
+	flagNoSquash           = flag.Bool("nosquash", false, "Don't squash layers and output every layer as ACI")
+	flagImage              = flag.String("image", "", "When converting a local file, it selects a particular image to convert. Format: IMAGE_NAME[:TAG]")
+	flagDebug              = flag.Bool("debug", false, "Enables debug messages")
+	flagInsecureSkipVerify = flag.Bool("insecure-skip-verify", false, "Accepts any certificate from the registry and any host name in that certificate")
+	flagInsecureRegistry   = flag.Bool("insecure-registry", false, "Uses a plain unencrypted HTTP registry")
 )
 
-func runDocker2ACI(arg string, flagNoSquash bool, flagImage string, flagDebug bool, flagInsecure bool) error {
+func runDocker2ACI(arg, flagImage string, flagNoSquash, flagDebug, flagInsecureSkipVerify, flagInsecureRegistry bool) error {
 	if flagDebug {
 		util.InitDebug()
 	}
@@ -61,7 +62,7 @@ func runDocker2ACI(arg string, flagNoSquash bool, flagImage string, flagDebug bo
 			return fmt.Errorf("error reading .dockercfg file: %v", err)
 		}
 
-		aciLayerPaths, err = docker2aci.Convert(dockerURL, squash, ".", os.TempDir(), username, password, flagInsecure)
+		aciLayerPaths, err = docker2aci.Convert(dockerURL, squash, ".", os.TempDir(), username, password, flagInsecureSkipVerify, flagInsecureRegistry)
 	} else {
 		aciLayerPaths, err = docker2aci.ConvertFile(flagImage, arg, squash, ".", os.TempDir())
 	}
@@ -157,7 +158,7 @@ func main() {
 		return
 	}
 
-	if err := runDocker2ACI(args[0], *flagNoSquash, *flagImage, *flagDebug, *flagInsecure); err != nil {
+	if err := runDocker2ACI(args[0], *flagImage, *flagNoSquash, *flagDebug, *flagInsecureSkipVerify, *flagInsecureRegistry); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}


### PR DESCRIPTION
Instead of having an --insecure flag that uses "http://" if it's
activated we add two flags:

- --insecure-skip-verify: accepts any certificate from the server but
  continues using TLS.
- --insecure-registry: uses a plain unencrypted HTTP registry.

Helps with https://github.com/coreos/rkt/issues/1829
Maps well with https://github.com/coreos/rkt/issues/1836