### PR TITLE
lib: allow relative paths in ImageManifest's App.Exec

### DIFF
--- a/lib/common/common.go
+++ b/lib/common/common.go
@@ -440,18 +440,7 @@ func writeACI(layer io.ReadSeeker, manifest schema.ImageManifest, curPwl []strin
 }
 
 func getExecCommand(entrypoint []string, cmd []string) appctypes.Exec {
-	var command []string
-	if entrypoint == nil && cmd == nil {
-		return nil
-	}
-	command = append(entrypoint, cmd...)
-	// non-absolute paths are not allowed, fallback to "/bin/sh -c command"
-	if len(command) > 0 && !filepath.IsAbs(command[0]) {
-		command_prefix := []string{"/bin/sh", "-c"}
-		quoted_command := util.Quote(command)
-		command = append(command_prefix, strings.Join(quoted_command, " "))
-	}
-	return command
+	return append(entrypoint, cmd...)
 }
 
 func parseDockerUser(dockerUser string) (string, string) {


### PR DESCRIPTION
Since https://github.com/appc/spec/pull/527 the spec allows relative
paths in App.Exec, so we don't need to prepend "/bin/sh -c".