### PR TITLE
lib/backend/repository: handle http and https gracefully

### DIFF
--- a/lib/backend/repository/repository.go
+++ b/lib/backend/repository/repository.go
@@ -14,9 +14,20 @@
 package repository
 
 import (
+	"fmt"
+	"net/http"
+	"path"
+
 	"github.com/appc/docker2aci/lib/common"
 	"github.com/appc/docker2aci/lib/types"
 	"github.com/appc/spec/schema"
+)
+
+type registryVersion int
+
+const (
+	registryV1 registryVersion = iota
+	registryV2
 )
 
 type RepositoryBackend struct {
@@ -26,6 +37,7 @@ type RepositoryBackend struct {
 	insecure          bool
 	hostsV2Support    map[string]bool
 	hostsV2AuthTokens map[string]map[string]string
+	schema            string
 	imageManifests    map[types.ParsedDockerURL]v2Manifest
 }
 
@@ -44,18 +56,29 @@ func (rb *RepositoryBackend) GetImageInfo(url string) ([]string, *types.ParsedDo
 	dockerURL := common.ParseDockerURL(url)
 
 	var supportsV2, ok bool
+	var URLSchema string
 	if supportsV2, ok = rb.hostsV2Support[dockerURL.IndexURL]; !ok {
 		var err error
-		supportsV2, err = rb.supportsV2(dockerURL.IndexURL)
+		URLSchema, supportsV2, err = rb.supportsRegistry(dockerURL.IndexURL, registryV2)
 		if err != nil {
 			return nil, nil, err
 		}
+		rb.schema = URLSchema + "://"
+		supportsV2 = false
 		rb.hostsV2Support[dockerURL.IndexURL] = supportsV2
 	}
 
 	if supportsV2 {
 		return rb.getImageInfoV2(dockerURL)
 	} else {
+		URLSchema, supportsV1, err := rb.supportsRegistry(dockerURL.IndexURL, registryV1)
+		if err != nil {
+			return nil, nil, err
+		}
+		if !supportsV1 {
+			return nil, nil, fmt.Errorf("registry doesn't support API v2 nor v1")
+		}
+		rb.schema = URLSchema + "://"
 		return rb.getImageInfoV1(dockerURL)
 	}
 }
@@ -68,10 +91,64 @@ func (rb *RepositoryBackend) BuildACI(layerNumber int, layerID string, dockerURL
 	}
 }
 
-func (rb *RepositoryBackend) protocol() string {
-	if rb.insecure {
-		return "http://"
-	} else {
-		return "https://"
+func checkRegistryStatus(statusCode int, hdr http.Header, version registryVersion) (bool, error) {
+	switch statusCode {
+	case http.StatusOK, http.StatusUnauthorized:
+		ok := true
+		if version == registryV2 {
+			// v2 API requires this check
+			ok = hdr.Get("Docker-Distribution-API-Version") == "registry/2.0"
+		}
+		return ok, nil
+	case http.StatusNotFound:
+		return false, nil
 	}
+
+	return false, fmt.Errorf("unexpected http code: %d", statusCode)
+}
+
+func (rb *RepositoryBackend) supportsRegistry(indexURL string, version registryVersion) (schema string, ok bool, err error) {
+	var URLPath string
+	switch version {
+	case registryV1:
+		// the v1 API defines this URL to check if the registry's status
+		URLPath = "v1/_ping"
+	case registryV2:
+		URLPath = "v2"
+	}
+	URLStr := path.Join(indexURL, URLPath)
+
+	fetch := func(schema string) (res *http.Response, err error) {
+		url := schema + "://" + URLStr
+		req, err := http.NewRequest("GET", url, nil)
+		if err != nil {
+			return nil, err
+		}
+
+		rb.setBasicAuth(req)
+
+		client := &http.Client{}
+		res, err = client.Do(req)
+		return
+	}
+
+	schema = "https"
+	res, err := fetch(schema)
+	if err == nil {
+		ok, err = checkRegistryStatus(res.StatusCode, res.Header, version)
+		defer res.Body.Close()
+	}
+	if err != nil || !ok {
+		if rb.insecure {
+			schema = "http"
+			res, err = fetch(schema)
+			if err == nil {
+				ok, err = checkRegistryStatus(res.StatusCode, res.Header, version)
+				defer res.Body.Close()
+			}
+		}
+		return schema, ok, err
+	}
+
+	return schema, ok, err
 }

--- a/lib/backend/repository/repository1.go
+++ b/lib/backend/repository/repository1.go
@@ -94,7 +94,7 @@ func (rb *RepositoryBackend) buildACIV1(layerNumber int, layerID string, dockerU
 
 func (rb *RepositoryBackend) getRepoDataV1(indexURL string, remote string) (*RepoData, error) {
 	client := &http.Client{}
-	repositoryURL := rb.protocol() + path.Join(indexURL, "v1", "repositories", remote, "images")
+	repositoryURL := rb.schema + path.Join(indexURL, "v1", "repositories", remote, "images")
 
 	req, err := http.NewRequest("GET", repositoryURL, nil)
 	if err != nil {
@@ -148,7 +148,7 @@ func (rb *RepositoryBackend) getImageIDFromTagV1(registry string, appName string
 	// requested one (.../tags/TAG) because even though it's specified in the
 	// Docker API, some registries (e.g. Google Container Registry) don't
 	// implement it.
-	req, err := http.NewRequest("GET", rb.protocol()+path.Join(registry, "repositories", appName, "tags"), nil)
+	req, err := http.NewRequest("GET", rb.schema+path.Join(registry, "repositories", appName, "tags"), nil)
 	if err != nil {
 		return "", fmt.Errorf("failed to get Image ID: %s, URL: %s", err, req.URL)
 	}
@@ -187,7 +187,7 @@ func (rb *RepositoryBackend) getImageIDFromTagV1(registry string, appName string
 
 func (rb *RepositoryBackend) getAncestryV1(imgID, registry string, repoData *RepoData) ([]string, error) {
 	client := &http.Client{}
-	req, err := http.NewRequest("GET", rb.protocol()+path.Join(registry, "images", imgID, "ancestry"), nil)
+	req, err := http.NewRequest("GET", rb.schema+path.Join(registry, "images", imgID, "ancestry"), nil)
 	if err != nil {
 		return nil, err
 	}
@@ -220,7 +220,7 @@ func (rb *RepositoryBackend) getAncestryV1(imgID, registry string, repoData *Rep
 
 func (rb *RepositoryBackend) getJsonV1(imgID, registry string, repoData *RepoData) ([]byte, int64, error) {
 	client := &http.Client{}
-	req, err := http.NewRequest("GET", rb.protocol()+path.Join(registry, "images", imgID, "json"), nil)
+	req, err := http.NewRequest("GET", rb.schema+path.Join(registry, "images", imgID, "json"), nil)
 	if err != nil {
 		return nil, -1, err
 	}
@@ -255,7 +255,7 @@ func (rb *RepositoryBackend) getJsonV1(imgID, registry string, repoData *RepoDat
 
 func (rb *RepositoryBackend) getLayerV1(imgID, registry string, repoData *RepoData, imgSize int64, tmpDir string) (*os.File, error) {
 	client := &http.Client{}
-	req, err := http.NewRequest("GET", rb.protocol()+path.Join(registry, "images", imgID, "layer"), nil)
+	req, err := http.NewRequest("GET", rb.schema+path.Join(registry, "images", imgID, "layer"), nil)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/docker2aci.go
+++ b/lib/docker2aci.go
@@ -232,7 +232,7 @@ func getManifests(renderedACI acirenderer.RenderedACI, aciRegistry acirenderer.A
 func writeSquashedImage(outputFile *os.File, renderedACI acirenderer.RenderedACI, aciProvider acirenderer.ACIProvider, manifests []schema.ImageManifest, compression common.Compression) error {
 	var tarWriterTarget io.WriteCloser = outputFile
 
-	switch(compression) {
+	switch compression {
 	case common.NoCompression:
 	case common.GzipCompression:
 		tarWriterTarget = gzip.NewWriter(outputFile)


### PR DESCRIPTION
If docker2aci is passed the `--insecure` flag, don't directly use http but
try https first and then http.

Helps with https://github.com/coreos/rkt/issues/2036