### PR TITLE
lib/repository: do not force Docker API v1

### DIFF
--- a/lib/backend/repository/repository.go
+++ b/lib/backend/repository/repository.go
@@ -64,7 +64,6 @@ func (rb *RepositoryBackend) GetImageInfo(url string) ([]string, *types.ParsedDo
 			return nil, nil, err
 		}
 		rb.schema = URLSchema + "://"
-		supportsV2 = false
 		rb.hostsV2Support[dockerURL.IndexURL] = supportsV2
 	}
 


### PR DESCRIPTION
I added this statement to force using Docker API v1 and test if it
worked and I forgot to remove it before pushing :$.