### PR TITLE
lib/common: infer default docker registry

### DIFF
--- a/lib/common/common.go
+++ b/lib/common/common.go
@@ -51,12 +51,12 @@ func ParseDockerURL(arg string) *types.ParsedDockerURL {
 	}
 	indexURL, imageName := SplitReposName(taglessRemote)
 
-	if indexURL == "" && !strings.Contains(imageName, "/") {
+	// the Docker client considers images referenced only by a name (e.g.
+	// "busybox" or "ubuntu") as valid, and, in that case, it adds the
+	// "library/" prefix because that's how they're stored in the official
+	// registry
+	if indexURL == defaultIndexURL && !strings.Contains(imageName, "/") {
 		imageName = "library/" + imageName
-	}
-
-	if indexURL == "" {
-		indexURL = defaultIndexURL
 	}
 
 	return &types.ParsedDockerURL{

--- a/lib/common/docker_functions.go
+++ b/lib/common/docker_functions.go
@@ -38,9 +38,7 @@ func SplitReposName(reposName string) (string, string) {
 	if len(nameParts) == 1 || (!strings.Contains(nameParts[0], ".") &&
 		!strings.Contains(nameParts[0], ":") && nameParts[0] != "localhost") {
 		// This is a Docker Index repos (ex: samalba/hipache or ubuntu)
-		// The URL for the index is different depending on the version of the
-		// API used to fetch it, so it cannot be inferred here.
-		indexName = ""
+		indexName = defaultIndexURL
 		remoteName = reposName
 	} else {
 		indexName = nameParts[0]


### PR DESCRIPTION
If the Docker reference does not include any servers, we assume it's a
using the default Docker registry.

Since the Docker API v1 was deprecated in the default registry, we can
now infer the default docker registry name (registry-1.docker.io).

Needed to fix https://github.com/coreos/rkt/issues/2008