### PR TITLE
support authentication, fix layers

### DIFF
--- a/lib/backend/repository/repository.go
+++ b/lib/backend/repository/repository.go
@@ -14,6 +14,7 @@
 package repository
 
 import (
+	"crypto/tls"
 	"fmt"
 	"net/http"
 	"path"
@@ -129,7 +130,8 @@ func (rb *RepositoryBackend) supportsRegistry(indexURL string, version registryV
 
 		rb.setBasicAuth(req)
 
-		client := &http.Client{}
+		tr := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: rb.insecure}}
+		client := &http.Client{Transport: tr}
 		res, err = client.Do(req)
 		return
 	}

--- a/lib/common/common.go
+++ b/lib/common/common.go
@@ -26,6 +26,7 @@ import (
 const (
 	defaultTag              = "latest"
 	defaultIndexURL         = "registry-1.docker.io"
+	defaultIndexURLAuth     = "https://index.docker.io/v1/"
 	schemaVersion           = "0.7.0"
 	appcDockerRegistryURL   = "appc.io/docker/registryurl"
 	appcDockerRepository    = "appc.io/docker/repository"

--- a/lib/docker2aci.go
+++ b/lib/docker2aci.go
@@ -45,7 +45,7 @@ type Docker2ACIBackend interface {
 // Convert generates ACI images from docker registry URLs.
 // It takes as input a dockerURL of the form:
 //
-// 	{docker registry URL}/{image name}:{tag}
+//     {registry URL}/{repository}:{reference[tag|digest]}
 //
 // It then gets all the layers of the requested image and converts each of
 // them to ACI.

--- a/lib/types/docker_types.go
+++ b/lib/types/docker_types.go
@@ -65,10 +65,22 @@ type DockerImageConfig struct {
 }
 
 // Taken from upstream Docker
-type DockerAuthConfig struct {
+type DockerAuthConfigOld struct {
 	Username      string `json:"username,omitempty"`
 	Password      string `json:"password,omitempty"`
 	Auth          string `json:"auth"`
 	Email         string `json:"email"`
 	ServerAddress string `json:"serveraddress,omitempty"`
+}
+
+type DockerAuthConfig struct {
+	Username      string `json:"username,omitempty"`
+	Password      string `json:"password,omitempty"`
+	Auth          string `json:"auth,omitempty"`
+	ServerAddress string `json:"serveraddress,omitempty"`
+	RegistryToken string `json:"registrytoken,omitempty"`
+}
+
+type DockerConfigFile struct {
+	AuthConfigs map[string]DockerAuthConfig `json:"auths"`
 }


### PR DESCRIPTION
This PR is fixing:

- fix layers in manifest before downloading them (upstream docker also does this)
- support for downloading images in the Docker Hub that are private
- fix Docker cofing for auth resolution (.dockercfg is obsolete, but I'll support it as a backup)
- if --insecure is provided - set InsecureSkipVerify in client's Transport

I left some TODO(s) as I'm continue working on it (probably will make a followup PR if this gets merged), I left some comments in the code, feel free to comment also.

@philips @jonboulle 
I'd like to have an ack to go ahead and clean this code and commits(if you accept this change) 

pull against Docker hub and private repositories:
BEFORE (wrong config file auths)
```
./bin/docker2aci --debug docker://runcom/busyboxt
Getting image info...
Error: conversion error: unexpected http code: 401, URL: https://registry-1.docker.io/v2/runcom/busyboxt/manifests/latest
``` 
AFTER
```
./bin/docker2aci --debug docker://runcom/busyboxt 
Getting image info...
Downloading sha256:eeee0535bf3: [==============================] 676 KB/676 KB 
Generating layer ACI...
Downloading sha256:a3ed95caeb0: [==============================] 32 B/32 B
Generating layer ACI...
Squashing layers...
Rendering ACI...
Writing squashed ACI...
Validating squashed ACI...
ACI squashed!

Generated ACI(s):
runcom-busyboxt-latest.aci
```

Signed-off-by: Antonio Murdaca <runcom@redhat.com>