### PR TITLE
lib/common: make a copy of pwl instead of reusing the same var

### DIFF
--- a/lib/common/common.go
+++ b/lib/common/common.go
@@ -433,10 +433,14 @@ func writeACI(layer io.ReadSeeker, manifest schema.ImageManifest, curPwl []strin
 	}
 	newPwl := subtractWhiteouts(curPwl, whiteouts)
 
-	manifest.PathWhitelist, err = writeStdioSymlinks(trw, fileMap, newPwl)
+	newPwl, err = writeStdioSymlinks(trw, fileMap, newPwl)
 	if err != nil {
 		return nil, err
 	}
+	// Let's copy the newly generated PathWhitelist to avoid unintended
+	// side-effects
+	manifest.PathWhitelist = make([]string, len(newPwl))
+	copy(manifest.PathWhitelist, newPwl)
 
 	if err := WriteManifest(trw, manifest); err != nil {
 		return nil, fmt.Errorf("error writing manifest: %v", err)

--- a/tests/rkt-v0.16.0.md5sum
+++ b/tests/rkt-v0.16.0.md5sum
@@ -1,1 +1,0 @@
-MD5(rkt-v0.16.0.tar.gz)= 77bec5424a3a488aa2dfcc0c147842a9

--- a/tests/rkt-v1.1.0.md5sum
+++ b/tests/rkt-v1.1.0.md5sum
@@ -1,0 +1,1 @@
+MD5 (rkt-v1.1.0.tar.gz) = d3d9d62429e53d8f631dbec93e4e719f

--- a/tests/test-pwl/Dockerfile
+++ b/tests/test-pwl/Dockerfile
@@ -1,0 +1,3 @@
+FROM gcr.io/google_containers/nginx:1.7.9
+COPY check.sh /
+ENTRYPOINT /check.sh 2>&1

--- a/tests/test-pwl/check.sh
+++ b/tests/test-pwl/check.sh
@@ -1,0 +1,6 @@
+#!/bin/sh
+set -e
+set -x
+
+ls -l /var/run
+echo "SUCCESS"

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -5,6 +5,7 @@ set -e
 DOCKER2ACI=../bin/docker2aci
 PREFIX=docker2aci-tests
 TESTDIR=$(dirname $(realpath $0))
+RKTVERSION=v1.1.0
 
 cd $TESTDIR
 
@@ -15,12 +16,12 @@ if ! which rkt > /dev/null ; then
 		exit 1
 	fi
 	pushd $SEMAPHORE_CACHE_DIR
-	if ! md5sum -c $TESTDIR/rkt-v0.16.0.md5sum; then
-		wget https://github.com/coreos/rkt/releases/download/v0.16.0/rkt-v0.16.0.tar.gz
+	if ! md5sum -c $TESTDIR/rkt-$RKTVERSION.md5sum; then
+		wget https://github.com/coreos/rkt/releases/download/$RKTVERSION/rkt-$RKTVERSION.tar.gz
 	fi
-	md5sum -c $TESTDIR/rkt-v0.16.0.md5sum
-	tar xf rkt-v0.16.0.tar.gz
-	export PATH=$PATH:$PWD/rkt-v0.16.0/
+	md5sum -c $TESTDIR/rkt-$RKTVERSION.md5sum
+	tar xf rkt-$RKTVERSION.tar.gz
+	export PATH=$PATH:$PWD/rkt-$RKTVERSION/
 	popd
 fi
 RKT=$(which rkt)


### PR DESCRIPTION
In f78ecc1d6e7c3fd913b0d374f759a5b6d3a628f2, we started sorting every
golang map before serializing the Image Manifests to make the generated
ACIs deterministic (golang randomizes maps).

This causes problems with squashed ACIs: they're missing some files (see
https://github.com/coreos/rkt/issues/2244 for some examples).

The reason for this is that we were modifying the PathWhitelist inside
writeACI() and then reusing the same copy in the next iteration of the
loop in convertReal(). Making a copy of the modified PathWhitelist when
we generate the layer's manifest fixes the problem.

cc @krnowak 