### PR TITLE
build: use `/usr/bin/env bash` instead of `/bin/bash`

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -1,4 +1,6 @@
-#!/bin/bash -e
+#!/usr/bin/env bash
+
+set -e
 
 ORG_PATH="github.com/appc"
 REPO_PATH="${ORG_PATH}/docker2aci"


### PR DESCRIPTION
Using `/usr/bin/env bash` instead of `/bin/bash` makes the build script
a little more portable, as it's not always safe to assume that
`/bin/bash` exists (for example, this is the case in NixOS).