### PR TITLE
lib/backend/repository; handle when auth challenge is missing scope

### DIFF
--- a/lib/backend/repository/repository2.go
+++ b/lib/backend/repository/repository2.go
@@ -358,7 +358,8 @@ func (rb *RepositoryBackend) makeRequest(req *http.Request, repo string) (*http.
 	}
 	// The scope can be empty if we're not getting a token for a specific repo
 	if scope == "" && repo != "" {
-		return nil, fmt.Errorf("missing scope in bearer auth challenge")
+		// If the scope is empty and it shouldn't be, we can infer it based on the repo
+		scope = fmt.Sprintf("repository:%s:pull", repo)
 	}
 
 	authReq, err := http.NewRequest("GET", realm, nil)


### PR DESCRIPTION
On some registries (like quay) the scope portion of the bearer auth
challenge can be omitted. In these situations docker2aci has all the
pieces it needs to infer the scope of the token to request, so this
commit changes docker2aci to do so when the scope is missing.