### PR TITLE
*: prepare release

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,16 +14,9 @@ disabled by specifying `--compression=none`.
 
 ## Build
 
-Installation is simple as:
-
-	go get github.com/appc/docker2aci
-
-or as involved as:
-
 	git clone git://github.com/appc/docker2aci
 	cd docker2aci
-	go get -d ./...
-	go build
+	./build.sh
 
 ## Volumes
 

--- a/build.sh
+++ b/build.sh
@@ -4,6 +4,9 @@ set -e
 
 ORG_PATH="github.com/appc"
 REPO_PATH="${ORG_PATH}/docker2aci"
+# TODO: use "git describe --dirty" when we actually have tags pushed
+VERSION=$(git rev-parse --short HEAD)
+GLDFLAGS="-X github.com/appc/docker2aci/lib.Version=${VERSION}"
 
 if [ ! -h gopath/src/${REPO_PATH} ]; then
 	mkdir -p gopath/src/${ORG_PATH}
@@ -18,5 +21,4 @@ eval $(go env)
 echo "Fetching dependencies..."
 go get -d -v ./...
 echo "Building docker2aci..."
-go build -o $GOBIN/docker2aci ${REPO_PATH}/
-
+go build -o $GOBIN/docker2aci -ldflags "${GLDFLAGS}" ${REPO_PATH}/

--- a/lib/conversion_store.go
+++ b/lib/conversion_store.go
@@ -23,18 +23,18 @@ type aciInfo struct {
 	ImageManifest *schema.ImageManifest
 }
 
-// ConversionStore is an simple implementation of the acirenderer.ACIRegistry
+// conversionStore is an simple implementation of the acirenderer.ACIRegistry
 // interface. It stores the Docker layers converted to ACI so we can take
 // advantage of acirenderer to generate a squashed ACI Image.
-type ConversionStore struct {
+type conversionStore struct {
 	acis map[string]*aciInfo
 }
 
-func NewConversionStore() *ConversionStore {
-	return &ConversionStore{acis: make(map[string]*aciInfo)}
+func newConversionStore() *conversionStore {
+	return &conversionStore{acis: make(map[string]*aciInfo)}
 }
 
-func (ms *ConversionStore) WriteACI(path string) (string, error) {
+func (ms *conversionStore) WriteACI(path string) (string, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return "", err
@@ -65,7 +65,7 @@ func (ms *ConversionStore) WriteACI(path string) (string, error) {
 	return key, nil
 }
 
-func (ms *ConversionStore) GetImageManifest(key string) (*schema.ImageManifest, error) {
+func (ms *conversionStore) GetImageManifest(key string) (*schema.ImageManifest, error) {
 	aci, ok := ms.acis[key]
 	if !ok {
 		return nil, fmt.Errorf("aci with key: %s not found", key)
@@ -73,7 +73,7 @@ func (ms *ConversionStore) GetImageManifest(key string) (*schema.ImageManifest, 
 	return aci.ImageManifest, nil
 }
 
-func (ms *ConversionStore) GetACI(name types.ACIdentifier, labels types.Labels) (string, error) {
+func (ms *conversionStore) GetACI(name types.ACIdentifier, labels types.Labels) (string, error) {
 	for _, aci := range ms.acis {
 		// we implement this function to comply with the interface so don't
 		// bother implementing a proper label check
@@ -84,7 +84,7 @@ func (ms *ConversionStore) GetACI(name types.ACIdentifier, labels types.Labels) 
 	return "", fmt.Errorf("aci not found")
 }
 
-func (ms *ConversionStore) ReadStream(key string) (io.ReadCloser, error) {
+func (ms *conversionStore) ReadStream(key string) (io.ReadCloser, error) {
 	img, ok := ms.acis[key]
 	if !ok {
 		return nil, fmt.Errorf("stream for key: %s not found", key)
@@ -102,11 +102,11 @@ func (ms *ConversionStore) ReadStream(key string) (io.ReadCloser, error) {
 	return tr, nil
 }
 
-func (ms *ConversionStore) ResolveKey(key string) (string, error) {
+func (ms *conversionStore) ResolveKey(key string) (string, error) {
 	return key, nil
 }
 
-func (ms *ConversionStore) HashToKey(h hash.Hash) string {
+func (ms *conversionStore) HashToKey(h hash.Hash) string {
 	s := h.Sum(nil)
 	return fmt.Sprintf("%s%x", hashPrefix, s)
 }

--- a/lib/docker2aci.go
+++ b/lib/docker2aci.go
@@ -61,25 +61,25 @@ type FileConfig struct {
 	DockerURL string // select an image if there are several images/tags in the file, Syntax: "{docker registry URL}/{image name}:{tag}"
 }
 
-// ConvertRepo generates ACI images from docker registry URLs.
-// It takes as input a dockerURL of the form:
+// ConvertRemoteRepo generates ACI images from docker registry URLs.  It takes
+// as input a dockerURL of the form:
 //
 //     {registry URL}/{repository}:{reference[tag|digest]}
 //
 // It then gets all the layers of the requested image and converts each of
 // them to ACI.
 // It returns the list of generated ACI paths.
-func Convert(dockerURL string, config RemoteConfig) ([]string, error) {
+func ConvertRemoteRepo(dockerURL string, config RemoteConfig) ([]string, error) {
 	repositoryBackend := repository.NewRepositoryBackend(config.Username, config.Password, config.Insecure)
 	return convertReal(repositoryBackend, dockerURL, config.Squash, config.OutputDir, config.TmpDir, config.Compression)
 }
 
-// ConvertFile generates ACI images from a file generated with "docker save".
-// If there are several images/tags in the file, a particular image can be
-// chosen via FileConfig.DockerURL.
+// ConvertSavedFile generates ACI images from a file generated with "docker
+// save".  If there are several images/tags in the file, a particular image can
+// be chosen via FileConfig.DockerURL.
 //
 // It returns the list of generated ACI paths.
-func ConvertFile(dockerSavedFile string, config FileConfig) ([]string, error) {
+func ConvertSavedFile(dockerSavedFile string, config FileConfig) ([]string, error) {
 	f, err := os.Open(dockerSavedFile)
 	if err != nil {
 		return nil, fmt.Errorf("error opening file: %v", err)

--- a/lib/docker2aci.go
+++ b/lib/docker2aci.go
@@ -114,7 +114,7 @@ func convertReal(backend Docker2ACIBackend, dockerURL string, squash bool, outpu
 		defer os.RemoveAll(layersOutputDir)
 	}
 
-	conversionStore := NewConversionStore()
+	conversionStore := newConversionStore()
 
 	var images acirenderer.Images
 	var aciLayerPaths []string
@@ -146,7 +146,7 @@ func convertReal(backend Docker2ACIBackend, dockerURL string, squash bool, outpu
 	// acirenderer expects images in order from upper to base layer
 	images = util.ReverseImages(images)
 	if squash {
-		squashedImagePath, err := SquashLayers(images, conversionStore, *parsedDockerURL, outputDir, compression)
+		squashedImagePath, err := squashLayers(images, conversionStore, *parsedDockerURL, outputDir, compression)
 		if err != nil {
 			return nil, fmt.Errorf("error squashing image: %v", err)
 		}
@@ -156,9 +156,9 @@ func convertReal(backend Docker2ACIBackend, dockerURL string, squash bool, outpu
 	return aciLayerPaths, nil
 }
 
-// SquashLayers receives a list of ACI layer file names ordered from base image
+// squashLayers receives a list of ACI layer file names ordered from base image
 // to application image and squashes them into one ACI
-func SquashLayers(images []acirenderer.Image, aciRegistry acirenderer.ACIRegistry, parsedDockerURL types.ParsedDockerURL, outputDir string, compression common.Compression) (path string, err error) {
+func squashLayers(images []acirenderer.Image, aciRegistry acirenderer.ACIRegistry, parsedDockerURL types.ParsedDockerURL, outputDir string, compression common.Compression) (path string, err error) {
 	util.Debug("Squashing layers...")
 	util.Debug("Rendering ACI...")
 	renderedACI, err := acirenderer.GetRenderedACIFromList(images, aciRegistry)

--- a/lib/version.go
+++ b/lib/version.go
@@ -1,0 +1,20 @@
+// Copyright 2015 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package docker2aci
+
+import "github.com/appc/spec/schema"
+
+var Version = "0.0.0+was-not-built-correctly"
+var AppcVersion = schema.AppContainerVersion

--- a/main.go
+++ b/main.go
@@ -188,7 +188,7 @@ func main() {
 
 	if len(args) < 1 {
 		usage()
-		return
+		os.Exit(2)
 	}
 
 	if err := runDocker2ACI(args[0], *flagNoSquash, *flagImage, *flagDebug, *flagInsecure, *flagCompression); err != nil {

--- a/main.go
+++ b/main.go
@@ -31,14 +31,29 @@ import (
 )
 
 var (
-	flagNoSquash    = flag.Bool("nosquash", false, "Don't squash layers and output every layer as ACI")
-	flagImage       = flag.String("image", "", "When converting a local file, it selects a particular image to convert. Format: IMAGE_NAME[:TAG]")
-	flagDebug       = flag.Bool("debug", false, "Enables debug messages")
-	flagInsecure    = flag.Bool("insecure", false, "Uses unencrypted connections when fetching images")
-	flagCompression = flag.String("compression", "gzip", "Type of compression to use; allowed values: gzip, none")
+	flagNoSquash    bool
+	flagImage       string
+	flagDebug       bool
+	flagInsecure    bool
+	flagCompression string
+	flagVersion     bool
 )
 
-func runDocker2ACI(arg string, flagNoSquash bool, flagImage string, flagDebug bool, flagInsecure bool, flagCompression string) error {
+func init() {
+	flag.BoolVar(&flagNoSquash, "nosquash", false, "Don't squash layers and output every layer as ACI")
+	flag.StringVar(&flagImage, "image", "", "When converting a local file, it selects a particular image to convert. Format: IMAGE_NAME[:TAG]")
+	flag.BoolVar(&flagDebug, "debug", false, "Enables debug messages")
+	flag.BoolVar(&flagInsecure, "insecure", false, "Uses unencrypted connections when fetching images")
+	flag.StringVar(&flagCompression, "compression", "gzip", "Type of compression to use; allowed values: gzip, none")
+	flag.BoolVar(&flagVersion, "version", false, "Print version")
+}
+
+func printVersion() {
+	fmt.Println("docker2aci version", docker2aci.Version)
+	fmt.Println("appc version", docker2aci.AppcVersion)
+}
+
+func runDocker2ACI(arg string) error {
 	if flagDebug {
 		util.InitDebug()
 	}
@@ -186,12 +201,17 @@ func main() {
 	flag.Parse()
 	args := flag.Args()
 
+	if flagVersion {
+		printVersion()
+		return
+	}
+
 	if len(args) < 1 {
 		usage()
 		os.Exit(2)
 	}
 
-	if err := runDocker2ACI(args[0], *flagNoSquash, *flagImage, *flagDebug, *flagInsecure, *flagCompression); err != nil {
+	if err := runDocker2ACI(args[0]); err != nil {
 		fmt.Fprintf(os.Stderr, "Error: %v\n", err)
 		os.Exit(1)
 	}

--- a/main.go
+++ b/main.go
@@ -22,6 +22,7 @@ import (
 	"strings"
 
 	"github.com/appc/docker2aci/lib"
+	"github.com/appc/docker2aci/lib/backend/file"
 	"github.com/appc/docker2aci/lib/common"
 	"github.com/appc/docker2aci/lib/util"
 
@@ -94,6 +95,9 @@ func runDocker2ACI(arg string, flagNoSquash bool, flagImage string, flagDebug bo
 			DockerURL:    flagImage,
 		}
 		aciLayerPaths, err = docker2aci.ConvertFile(arg, fileConfig)
+		if serr, ok := err.(*file.ErrSeveralImages); ok {
+			err = fmt.Errorf("%s, use option --image with one of:\n\n%s", serr, strings.Join(serr.Images, "\n"))
+		}
 	}
 	if err != nil {
 		return fmt.Errorf("conversion error: %v", err)

--- a/main.go
+++ b/main.go
@@ -88,13 +88,13 @@ func runDocker2ACI(arg string, flagNoSquash bool, flagImage string, flagDebug bo
 			Insecure:     flagInsecure,
 		}
 
-		aciLayerPaths, err = docker2aci.Convert(dockerURL, remoteConfig)
+		aciLayerPaths, err = docker2aci.ConvertRemoteRepo(dockerURL, remoteConfig)
 	} else {
 		fileConfig := docker2aci.FileConfig{
 			CommonConfig: cfg,
 			DockerURL:    flagImage,
 		}
-		aciLayerPaths, err = docker2aci.ConvertFile(arg, fileConfig)
+		aciLayerPaths, err = docker2aci.ConvertSavedFile(arg, fileConfig)
 		if serr, ok := err.(*file.ErrSeveralImages); ok {
 			err = fmt.Errorf("%s, use option --image with one of:\n\n%s", serr, strings.Join(serr.Images, "\n"))
 		}


### PR DESCRIPTION
This PR includes commits that prepare the first docker2aci release:

* Clean the API by reducing the exposed functions and using config structs instead of individual parameters.
* Decouple an library error message from the docker2aci CLI
* Change the names of the Convert functions
* Exit with status 2 when the arguments are invalid
* Add version flag
* Update build instructions 