### PR TITLE
build.sh: remove fetching dependencies

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -17,7 +17,5 @@ export GOPATH=${PWD}/gopath:${PWD}/Godeps/_workspace
 
 eval $(go env)
 
-echo "Fetching dependencies..."
-go get -d -v ./...
 echo "Building docker2aci..."
 go build -o $GOBIN/docker2aci -ldflags "${GLDFLAGS}" ${REPO_PATH}/


### PR DESCRIPTION
We're vendoring the dependencies now, there's no need to fetch them.