### PR TITLE
util, repository: Use a default transport

### DIFF
--- a/lib/internal/backend/repository/repository.go
+++ b/lib/internal/backend/repository/repository.go
@@ -20,7 +20,6 @@
 package repository
 
 import (
-	"crypto/tls"
 	"fmt"
 	"net/http"
 	"path"
@@ -28,6 +27,7 @@ import (
 	"github.com/appc/docker2aci/lib/common"
 	"github.com/appc/docker2aci/lib/internal/docker"
 	"github.com/appc/docker2aci/lib/internal/types"
+	"github.com/appc/docker2aci/lib/internal/util"
 	"github.com/appc/spec/schema"
 )
 
@@ -137,8 +137,7 @@ func (rb *RepositoryBackend) supportsRegistry(indexURL string, version registryV
 
 		rb.setBasicAuth(req)
 
-		tr := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: rb.insecure}}
-		client := &http.Client{Transport: tr}
+		client := util.GetTLSClient(rb.insecure)
 		res, err = client.Do(req)
 		return
 	}

--- a/lib/internal/backend/repository/repository2.go
+++ b/lib/internal/backend/repository/repository2.go
@@ -15,7 +15,6 @@
 package repository
 
 import (
-	"crypto/tls"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -32,6 +31,7 @@ import (
 	"github.com/appc/docker2aci/lib/common"
 	"github.com/appc/docker2aci/lib/internal"
 	"github.com/appc/docker2aci/lib/internal/types"
+	"github.com/appc/docker2aci/lib/internal/util"
 	"github.com/appc/docker2aci/pkg/log"
 	"github.com/appc/spec/schema"
 	"github.com/coreos/ioprogress"
@@ -315,8 +315,7 @@ func (rb *RepositoryBackend) makeRequest(req *http.Request, repo string) (*http.
 		}
 	}
 
-	tr := &http.Transport{TLSClientConfig: &tls.Config{InsecureSkipVerify: rb.insecure}}
-	client := &http.Client{Transport: tr}
+	client := util.GetTLSClient(rb.insecure)
 	res, err := client.Do(req)
 	if err != nil {
 		return nil, err

--- a/lib/internal/util/util.go
+++ b/lib/internal/util/util.go
@@ -19,7 +19,9 @@
 package util
 
 import (
+	"crypto/tls"
 	"fmt"
+	"net/http"
 
 	"github.com/appc/spec/pkg/acirenderer"
 )
@@ -58,4 +60,24 @@ func IndexOf(list []string, el string) int {
 		}
 	}
 	return -1
+}
+
+// GetTLSClient gets an HTTP client that behaves like the default HTTP
+// client, but optionally skips the TLS certificate verification.
+func GetTLSClient(skipTLSCheck bool) *http.Client {
+	if !skipTLSCheck {
+		return http.DefaultClient
+	}
+	client := *http.DefaultClient
+	// Default transport is hidden behind the RoundTripper
+	// interface, so we can't easily make a copy of it. If this
+	// ever panics, we will have to adapt.
+	realTransport := http.DefaultTransport.(*http.Transport)
+	tr := *realTransport
+	if tr.TLSClientConfig == nil {
+		tr.TLSClientConfig = &tls.Config{}
+	}
+	tr.TLSClientConfig.InsecureSkipVerify = true
+	client.Transport = &tr
+	return &client
 }


### PR DESCRIPTION
Creating a transport like &http.Transport{} and modifying its
TLSClientConfig turns off proxy support.