### PR TITLE
backend/repository: pull layers in parallel

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -47,6 +47,11 @@
 			"Rev": "e7fc03058804de5488baed8df5b89f3924b9ec9a"
 		},
 		{
+			"ImportPath": "github.com/coreos/pkg/progressutil",
+			"Comment": "v1",
+			"Rev": "160ae6282d8c48a33d8c150e4e4817fdef8a5cde"
+		},
+		{
 			"ImportPath": "github.com/docker/distribution/digest",
 			"Comment": "v2.3.0",
 			"Rev": "099622876197e3b24d627a72053d1bcc8968076a"

--- a/Godeps/_workspace/src/github.com/coreos/pkg/LICENSE
+++ b/Godeps/_workspace/src/github.com/coreos/pkg/LICENSE
@@ -1,0 +1,202 @@
+Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.
+

--- a/Godeps/_workspace/src/github.com/coreos/pkg/NOTICE
+++ b/Godeps/_workspace/src/github.com/coreos/pkg/NOTICE
@@ -1,0 +1,5 @@
+CoreOS Project
+Copyright 2014 CoreOS, Inc
+
+This product includes software developed at CoreOS, Inc.
+(http://www.coreos.com/).

--- a/Godeps/_workspace/src/github.com/coreos/pkg/progressutil/iocopy.go
+++ b/Godeps/_workspace/src/github.com/coreos/pkg/progressutil/iocopy.go
@@ -1,0 +1,167 @@
+// Copyright 2016 CoreOS Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package progressutil
+
+import (
+	"fmt"
+	"io"
+	"sync"
+	"time"
+)
+
+type copyReader struct {
+	reader  io.Reader
+	current int64
+	total   int64
+	done    bool
+	pb      *ProgressBar
+}
+
+func (cr *copyReader) Read(p []byte) (int, error) {
+	n, err := cr.reader.Read(p)
+	cr.current += int64(n)
+	err1 := cr.updateProgressBar()
+	if err == nil {
+		err = err1
+	}
+	if err != nil {
+		cr.done = true
+	}
+	return n, err
+}
+
+func (cr *copyReader) updateProgressBar() error {
+	cr.pb.SetPrintAfter(cr.formattedProgress())
+
+	progress := float64(cr.current) / float64(cr.total)
+	if progress > 1 {
+		progress = 1
+	}
+	return cr.pb.SetCurrentProgress(progress)
+}
+
+// CopyProgressPrinter will perform an arbitrary number of io.Copy calls, while
+// continually printing the progress of each copy.
+type CopyProgressPrinter struct {
+	readers []*copyReader
+	errors  []error
+	lock    sync.Mutex
+	pbp     *ProgressBarPrinter
+}
+
+// AddCopy adds a copy for this CopyProgressPrinter to perform. An io.Copy call
+// will be made to copy bytes from reader to dest, and name and size will be
+// used to label the progress bar and display how much progress has been made.
+// If size is 0, the total size of the reader is assumed to be unknown.
+func (cpp *CopyProgressPrinter) AddCopy(reader io.Reader, name string, size int64, dest io.Writer) {
+	cpp.lock.Lock()
+	if cpp.pbp == nil {
+		cpp.pbp = &ProgressBarPrinter{}
+		cpp.pbp.PadToBeEven = true
+	}
+
+	cr := &copyReader{
+		reader:  reader,
+		current: 0,
+		total:   size,
+		pb:      cpp.pbp.AddProgressBar(),
+	}
+	cr.pb.SetPrintBefore(name)
+	cr.pb.SetPrintAfter(cr.formattedProgress())
+
+	cpp.readers = append(cpp.readers, cr)
+	cpp.lock.Unlock()
+
+	go func() {
+		_, err := io.Copy(dest, cr)
+		if err != nil {
+			cpp.lock.Lock()
+			cpp.errors = append(cpp.errors, err)
+			cpp.lock.Unlock()
+		}
+	}()
+}
+
+// PrintAndWait will print the progress for each copy operation added with
+// AddCopy to printTo every printInterval. This will continue until every added
+// copy is finished, or until cancel is written to.
+func (cpp *CopyProgressPrinter) PrintAndWait(printTo io.Writer, printInterval time.Duration, cancel chan struct{}) error {
+	for {
+		// If cancel is not nil, see if anything has been written to it. If
+		// something has, return, otherwise keep drawing.
+		if cancel != nil {
+			select {
+			case <-cancel:
+				return nil
+			default:
+			}
+		}
+
+		cpp.lock.Lock()
+		readers := cpp.readers
+		errors := cpp.errors
+		cpp.lock.Unlock()
+
+		if len(errors) > 0 {
+			return errors[0]
+		}
+
+		if len(readers) > 0 {
+			_, err := cpp.pbp.Print(printTo)
+			if err != nil {
+				return err
+			}
+		} else {
+		}
+
+		allDone := true
+		for _, r := range readers {
+			allDone = allDone && r.done
+		}
+		if allDone && len(readers) > 0 {
+			return nil
+		}
+
+		time.Sleep(printInterval)
+	}
+}
+
+func (cr *copyReader) formattedProgress() string {
+	var totalStr string
+	if cr.total == 0 {
+		totalStr = "?"
+	} else {
+		totalStr = ByteUnitStr(cr.total)
+	}
+	return fmt.Sprintf("%s / %s", ByteUnitStr(cr.current), totalStr)
+}
+
+var byteUnits = []string{"B", "KB", "MB", "GB", "TB", "PB"}
+
+// ByteUnitStr pretty prints a number of bytes.
+func ByteUnitStr(n int64) string {
+	var unit string
+	size := float64(n)
+	for i := 1; i < len(byteUnits); i++ {
+		if size < 1000 {
+			unit = byteUnits[i-1]
+			break
+		}
+
+		size = size / 1000
+	}
+
+	return fmt.Sprintf("%.3g %s", size, unit)
+}

--- a/Godeps/_workspace/src/github.com/coreos/pkg/progressutil/progressbar.go
+++ b/Godeps/_workspace/src/github.com/coreos/pkg/progressutil/progressbar.go
@@ -1,0 +1,207 @@
+// Copyright 2016 CoreOS Inc
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package progressutil
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"sync"
+
+	"golang.org/x/crypto/ssh/terminal"
+)
+
+var (
+	// ErrorProgressOutOfBounds is returned if the progress is set to a value
+	// not between 0 and 1.
+	ErrorProgressOutOfBounds = fmt.Errorf("progress is out of bounds (0 to 1)")
+
+	// ErrorNoBarsAdded is returned when no progress bars have been added to a
+	// ProgressBarPrinter before PrintAndWait is called.
+	ErrorNoBarsAdded = fmt.Errorf("AddProgressBar hasn't been called yet")
+)
+
+// ProgressBar represents one progress bar in a ProgressBarPrinter. Should not
+// be created directly, use the AddProgressBar on a ProgressBarPrinter to
+// create these.
+type ProgressBar struct {
+	currentProgress float64
+	printBefore     string
+	printAfter      string
+	lock            sync.Mutex
+	done            bool
+}
+
+// SetCurrentProgress sets the progress of this ProgressBar. The progress must
+// be between 0 and 1 inclusive.
+func (pb *ProgressBar) SetCurrentProgress(progress float64) error {
+	if progress < 0 || progress > 1 {
+		return ErrorProgressOutOfBounds
+	}
+	pb.lock.Lock()
+	pb.currentProgress = progress
+	pb.lock.Unlock()
+	return nil
+}
+
+// SetPrintBefore sets the text printed on the line before the progress bar.
+func (pb *ProgressBar) SetPrintBefore(before string) {
+	pb.lock.Lock()
+	pb.printBefore = before
+	pb.lock.Unlock()
+}
+
+// SetPrintAfter sets the text printed on the line after the progress bar.
+func (pb *ProgressBar) SetPrintAfter(after string) {
+	pb.lock.Lock()
+	pb.printAfter = after
+	pb.lock.Unlock()
+}
+
+// ProgressBarPrinter will print out the progress of some number of
+// ProgressBars.
+type ProgressBarPrinter struct {
+	// DisplayWidth can be set to influence how large the progress bars are.
+	// The bars will be scaled to attempt to produce lines of this number of
+	// characters, but lines of different lengths may still be printed. When
+	// this value is 0 (aka unset), 80 character columns are assumed.
+	DisplayWidth int
+	// PadToBeEven, when set to true, will make Print pad the printBefore text
+	// with trailing spaces and the printAfter text with leading spaces to make
+	// the progress bars the same length.
+	PadToBeEven         bool
+	numLinesInLastPrint int
+	progressBars        []*ProgressBar
+	lock                sync.Mutex
+}
+
+// AddProgressBar will create a new ProgressBar, register it with this
+// ProgressBarPrinter, and return it. This must be called at least once before
+// PrintAndWait is called.
+func (pbp *ProgressBarPrinter) AddProgressBar() *ProgressBar {
+	pb := &ProgressBar{}
+	pbp.lock.Lock()
+	pbp.progressBars = append(pbp.progressBars, pb)
+	pbp.lock.Unlock()
+	return pb
+}
+
+// Print will print out progress information for each ProgressBar that has been
+// added to this ProgressBarPrinter. The progress will be written to printTo,
+// and if printTo is a terminal it will draw progress bars.  AddProgressBar
+// must be called at least once before Print is called. If printing to a
+// terminal, all draws after the first one will move the cursor up to draw over
+// the previously printed bars.
+func (pbp *ProgressBarPrinter) Print(printTo io.Writer) (bool, error) {
+	pbp.lock.Lock()
+	bars := pbp.progressBars
+	numColumns := pbp.DisplayWidth
+	pbp.lock.Unlock()
+
+	if len(bars) == 0 {
+		return false, ErrorNoBarsAdded
+	}
+
+	if numColumns == 0 {
+		numColumns = 80
+	}
+
+	if isTerminal(printTo) {
+		moveCursorUp(printTo, pbp.numLinesInLastPrint)
+	}
+
+	maxBefore := 0
+	maxAfter := 0
+	for _, bar := range bars {
+		bar.lock.Lock()
+		beforeSize := len(bar.printBefore)
+		afterSize := len(bar.printAfter)
+		bar.lock.Unlock()
+		if beforeSize > maxBefore {
+			maxBefore = beforeSize
+		}
+		if afterSize > maxAfter {
+			maxAfter = afterSize
+		}
+	}
+
+	allDone := false
+	for _, bar := range bars {
+		if isTerminal(printTo) {
+			bar.printToTerminal(printTo, numColumns, pbp.PadToBeEven, maxBefore, maxAfter)
+		} else {
+			bar.printToNonTerminal(printTo)
+		}
+		allDone = allDone || bar.currentProgress == 1
+	}
+
+	pbp.numLinesInLastPrint = len(bars)
+
+	return allDone, nil
+}
+
+// moveCursorUp moves the cursor up numLines in the terminal
+func moveCursorUp(printTo io.Writer, numLines int) {
+	if numLines > 0 {
+		fmt.Fprintf(printTo, "\033[%dA", numLines)
+	}
+}
+
+func (pb *ProgressBar) printToTerminal(printTo io.Writer, numColumns int, padding bool, maxBefore, maxAfter int) {
+	pb.lock.Lock()
+	before := pb.printBefore
+	after := pb.printAfter
+
+	if padding {
+		before = before + strings.Repeat(" ", maxBefore-len(before))
+		after = strings.Repeat(" ", maxAfter-len(after)) + after
+	}
+
+	progressBarSize := numColumns - (len(fmt.Sprintf("%s [] %s", before, after)))
+	progressBar := ""
+	if progressBarSize > 0 {
+		currentProgress := int(pb.currentProgress * float64(progressBarSize))
+		progressBar = fmt.Sprintf("[%s%s] ",
+			strings.Repeat("=", currentProgress),
+			strings.Repeat(" ", progressBarSize-currentProgress))
+	} else {
+		// If we can't fit the progress bar, better to not pad the before/after.
+		before = pb.printBefore
+		after = pb.printAfter
+	}
+
+	fmt.Fprintf(printTo, "%s %s%s\n", before, progressBar, after)
+	pb.lock.Unlock()
+}
+
+func (pb *ProgressBar) printToNonTerminal(printTo io.Writer) {
+	pb.lock.Lock()
+	if !pb.done {
+		fmt.Fprintf(printTo, "%s %s\n", pb.printBefore, pb.printAfter)
+		if pb.currentProgress == 1 {
+			pb.done = true
+		}
+	}
+	pb.lock.Unlock()
+}
+
+// isTerminal returns True when w is going to a tty, and false otherwise.
+func isTerminal(w io.Writer) bool {
+	if f, ok := w.(*os.File); ok {
+		return terminal.IsTerminal(int(f.Fd()))
+	}
+	return false
+}

--- a/lib/docker2aci.go
+++ b/lib/docker2aci.go
@@ -124,31 +124,25 @@ func convertReal(backend internal.Docker2ACIBackend, dockerURL string, squash bo
 
 	conversionStore := newConversionStore()
 
+	// only compress individual layers if we're not squashing
+	layerCompression := compression
+	if squash {
+		layerCompression = common.NoCompression
+	}
+
+	aciLayerPaths, aciManifests, err := backend.BuildACI(ancestry, parsedDockerURL, layersOutputDir, tmpDir, layerCompression)
+	if err != nil {
+		return nil, err
+	}
+
 	var images acirenderer.Images
-	var aciLayerPaths []string
-	var curPwl []string
-	for i := len(ancestry) - 1; i >= 0; i-- {
-		layerID := ancestry[i]
-
-		// only compress individual layers if we're not squashing
-		layerCompression := compression
-		if squash {
-			layerCompression = common.NoCompression
-		}
-
-		aciPath, manifest, err := backend.BuildACI(i, layerID, parsedDockerURL, layersOutputDir, tmpDir, curPwl, layerCompression)
-		if err != nil {
-			return nil, fmt.Errorf("error building layer: %v", err)
-		}
-
-		key, err := conversionStore.WriteACI(aciPath)
+	for i, aciLayerPath := range aciLayerPaths {
+		key, err := conversionStore.WriteACI(aciLayerPath)
 		if err != nil {
 			return nil, fmt.Errorf("error inserting in the conversion store: %v", err)
 		}
 
-		images = append(images, acirenderer.Image{Im: manifest, Key: key, Level: uint16(i)})
-		aciLayerPaths = append(aciLayerPaths, aciPath)
-		curPwl = manifest.PathWhitelist
+		images = append(images, acirenderer.Image{Im: aciManifests[i], Key: key, Level: uint16(len(aciLayerPaths) - 1 - i)})
 	}
 
 	// acirenderer expects images in order from upper to base layer

--- a/lib/internal/backend/repository/repository.go
+++ b/lib/internal/backend/repository/repository.go
@@ -93,11 +93,11 @@ func (rb *RepositoryBackend) GetImageInfo(url string) ([]string, *types.ParsedDo
 	}
 }
 
-func (rb *RepositoryBackend) BuildACI(layerNumber int, layerID string, dockerURL *types.ParsedDockerURL, outputDir string, tmpBaseDir string, curPwl []string, compression common.Compression) (string, *schema.ImageManifest, error) {
+func (rb *RepositoryBackend) BuildACI(layerIDs []string, dockerURL *types.ParsedDockerURL, outputDir string, tmpBaseDir string, compression common.Compression) ([]string, []*schema.ImageManifest, error) {
 	if rb.hostsV2Support[dockerURL.IndexURL] {
-		return rb.buildACIV2(layerNumber, layerID, dockerURL, outputDir, tmpBaseDir, curPwl, compression)
+		return rb.buildACIV2(layerIDs, dockerURL, outputDir, tmpBaseDir, compression)
 	} else {
-		return rb.buildACIV1(layerNumber, layerID, dockerURL, outputDir, tmpBaseDir, curPwl, compression)
+		return rb.buildACIV1(layerIDs, dockerURL, outputDir, tmpBaseDir, compression)
 	}
 }
 

--- a/lib/internal/backend/repository/repository2.go
+++ b/lib/internal/backend/repository/repository2.go
@@ -34,7 +34,7 @@ import (
 	"github.com/appc/docker2aci/lib/internal/util"
 	"github.com/appc/docker2aci/pkg/log"
 	"github.com/appc/spec/schema"
-	"github.com/coreos/ioprogress"
+	"github.com/coreos/pkg/progressutil"
 )
 
 const (
@@ -66,42 +66,96 @@ func (rb *RepositoryBackend) getImageInfoV2(dockerURL *types.ParsedDockerURL) ([
 	return layers, dockerURL, nil
 }
 
-func (rb *RepositoryBackend) buildACIV2(layerNumber int, layerID string, dockerURL *types.ParsedDockerURL, outputDir string, tmpBaseDir string, curPwl []string, compression common.Compression) (string, *schema.ImageManifest, error) {
-	manifest := rb.imageManifests[*dockerURL]
+func (rb *RepositoryBackend) buildACIV2(layerIDs []string, dockerURL *types.ParsedDockerURL, outputDir string, tmpBaseDir string, compression common.Compression) ([]string, []*schema.ImageManifest, error) {
+	layerFiles := make([]*os.File, len(layerIDs))
+	layerDatas := make([]types.DockerImageData, len(layerIDs))
 
-	layerIndex, err := getLayerIndex(layerID, manifest)
+	tmpParentDir, err := ioutil.TempDir(tmpBaseDir, "docker2aci-")
 	if err != nil {
-		return "", nil, err
+		return nil, nil, err
 	}
+	defer os.RemoveAll(tmpParentDir)
 
-	if len(manifest.History) <= layerIndex {
-		return "", nil, fmt.Errorf("history not found for layer %s", layerID)
+	copier := &progressutil.CopyProgressPrinter{}
+
+	var errChannels []chan error
+	closers := make([]io.ReadCloser, len(layerIDs))
+	for i, layerID := range layerIDs {
+		errChan := make(chan error)
+		errChannels = append(errChannels, errChan)
+		// https://github.com/golang/go/wiki/CommonMistakes
+		i := i // golang--
+		layerID := layerID
+		go func() {
+			manifest := rb.imageManifests[*dockerURL]
+
+			layerIndex, err := getLayerIndex(layerID, manifest)
+			if err != nil {
+				errChan <- err
+				return
+			}
+
+			if len(manifest.History) <= layerIndex {
+				errChan <- fmt.Errorf("history not found for layer %s", layerID)
+				return
+			}
+
+			layerDatas[i] = types.DockerImageData{}
+			if err := json.Unmarshal([]byte(manifest.History[layerIndex].V1Compatibility), &layerDatas[i]); err != nil {
+				errChan <- fmt.Errorf("error unmarshaling layer data: %v", err)
+				return
+			}
+
+			tmpDir, err := ioutil.TempDir(tmpParentDir, "")
+			if err != nil {
+				errChan <- fmt.Errorf("error creating dir: %v", err)
+				return
+			}
+
+			layerFiles[i], closers[i], err = rb.getLayerV2(layerID, dockerURL, tmpDir, copier)
+			if err != nil {
+				errChan <- fmt.Errorf("error getting the remote layer: %v", err)
+				return
+			}
+			errChan <- nil
+		}()
 	}
-
-	layerData := types.DockerImageData{}
-	if err := json.Unmarshal([]byte(manifest.History[layerIndex].V1Compatibility), &layerData); err != nil {
-		return "", nil, fmt.Errorf("error unmarshaling layer data: %v", err)
-	}
-
-	tmpDir, err := ioutil.TempDir(tmpBaseDir, "docker2aci-")
+	err = copier.PrintAndWait(os.Stderr, 500*time.Millisecond, nil)
 	if err != nil {
-		return "", nil, fmt.Errorf("error creating dir: %v", err)
+		return nil, nil, err
 	}
-	defer os.RemoveAll(tmpDir)
-
-	layerFile, err := rb.getLayerV2(layerID, dockerURL, tmpDir)
-	if err != nil {
-		return "", nil, fmt.Errorf("error getting the remote layer: %v", err)
+	for _, closer := range closers {
+		closer.Close()
 	}
-	defer layerFile.Close()
+	for _, errChan := range errChannels {
+		err := <-errChan
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	for _, layerFile := range layerFiles {
+		err := layerFile.Sync()
+		if err != nil {
+			return nil, nil, err
+		}
+	}
+	var aciLayerPaths []string
+	var aciManifests []*schema.ImageManifest
+	var curPwl []string
+	for i := len(layerIDs) - 1; i >= 0; i-- {
+		log.Debug("Generating layer ACI...")
+		aciPath, aciManifest, err := internal.GenerateACI(i, layerDatas[i], dockerURL, outputDir, layerFiles[i], curPwl, compression)
+		if err != nil {
+			return nil, nil, fmt.Errorf("error generating ACI: %v", err)
+		}
+		aciLayerPaths = append(aciLayerPaths, aciPath)
+		aciManifests = append(aciManifests, aciManifest)
+		curPwl = aciManifest.PathWhitelist
 
-	log.Debug("Generating layer ACI...")
-	aciPath, aciManifest, err := internal.GenerateACI(layerNumber, layerData, dockerURL, outputDir, layerFile, curPwl, compression)
-	if err != nil {
-		return "", nil, fmt.Errorf("error generating ACI: %v", err)
+		layerFiles[i].Close()
 	}
 
-	return aciPath, aciManifest, nil
+	return aciLayerPaths, aciManifests, nil
 }
 
 func (rb *RepositoryBackend) getManifestV2(dockerURL *types.ParsedDockerURL) (*v2Manifest, []string, error) {
@@ -224,84 +278,61 @@ func getLayerIndex(layerID string, manifest v2Manifest) (int, error) {
 	return -1, fmt.Errorf("layer not found in manifest: %s", layerID)
 }
 
-func (rb *RepositoryBackend) getLayerV2(layerID string, dockerURL *types.ParsedDockerURL, tmpDir string) (*os.File, error) {
+func (rb *RepositoryBackend) getLayerV2(layerID string, dockerURL *types.ParsedDockerURL, tmpDir string, copier *progressutil.CopyProgressPrinter) (*os.File, io.ReadCloser, error) {
 	url := rb.schema + path.Join(dockerURL.IndexURL, "v2", dockerURL.ImageName, "blobs", layerID)
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
 	rb.setBasicAuth(req)
 
 	res, err := rb.makeRequest(req, dockerURL.ImageName)
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
-	defer res.Body.Close()
 
 	if res.StatusCode == http.StatusTemporaryRedirect || res.StatusCode == http.StatusFound {
 		location := res.Header.Get("Location")
 		if location != "" {
 			req, err = http.NewRequest("GET", location, nil)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			res, err = rb.makeRequest(req, dockerURL.ImageName)
 			if err != nil {
-				return nil, err
+				return nil, nil, err
 			}
 			defer res.Body.Close()
 		}
 	}
 
 	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("HTTP code: %d. URL: %s", res.StatusCode, req.URL)
+		return nil, nil, fmt.Errorf("HTTP code: %d. URL: %s", res.StatusCode, req.URL)
 	}
 
 	var in io.Reader
 	in = res.Body
 
-	if hdr := res.Header.Get("Content-Length"); hdr != "" {
-		imgSize, err := strconv.ParseInt(hdr, 10, 64)
-		if err != nil {
-			return nil, err
-		}
+	var size int64
 
-		prefix := "Downloading " + layerID[:18]
-		fmtBytesSize := 18
-		barSize := int64(80 - len(prefix) - fmtBytesSize)
-		bar := ioprogress.DrawTextFormatBarForW(barSize, os.Stderr)
-		fmtfunc := func(progress, total int64) string {
-			return fmt.Sprintf(
-				"%s: %s %s",
-				prefix,
-				bar(progress, total),
-				ioprogress.DrawTextFormatBytes(progress, total),
-			)
-		}
-		in = &ioprogress.Reader{
-			Reader:       res.Body,
-			Size:         imgSize,
-			DrawFunc:     ioprogress.DrawTerminalf(os.Stderr, fmtfunc),
-			DrawInterval: 500 * time.Millisecond,
+	if hdr := res.Header.Get("Content-Length"); hdr != "" {
+		size, err = strconv.ParseInt(hdr, 10, 64)
+		if err != nil {
+			return nil, nil, err
 		}
 	}
+
+	name := "Downloading " + layerID[:18]
 
 	layerFile, err := ioutil.TempFile(tmpDir, "dockerlayer-")
 	if err != nil {
-		return nil, err
+		return nil, nil, err
 	}
 
-	_, err = io.Copy(layerFile, in)
-	if err != nil {
-		return nil, err
-	}
+	copier.AddCopy(in, name, size, layerFile)
 
-	if err := layerFile.Sync(); err != nil {
-		return nil, err
-	}
-
-	return layerFile, nil
+	return layerFile, res.Body, nil
 }
 
 func (rb *RepositoryBackend) makeRequest(req *http.Request, repo string) (*http.Response, error) {

--- a/lib/internal/internal.go
+++ b/lib/internal/internal.go
@@ -52,7 +52,7 @@ import (
 // path and its converted ImageManifest.
 type Docker2ACIBackend interface {
 	GetImageInfo(dockerUrl string) ([]string, *types.ParsedDockerURL, error)
-	BuildACI(layerNumber int, layerID string, dockerURL *types.ParsedDockerURL, outputDir string, tmpBaseDir string, curPWl []string, compression common.Compression) (string, *schema.ImageManifest, error)
+	BuildACI(layerIDs []string, dockerURL *types.ParsedDockerURL, outputDir string, tmpBaseDir string, compression common.Compression) ([]string, []*schema.ImageManifest, error)
 }
 
 // GenerateACI takes a Docker layer and generates an ACI from it.


### PR DESCRIPTION
This is #152 with a bugfix.

> To reduce the time it takes to fetch docker images, this commit modifies
the backends to pull each image layer concurrently. As a result,
github.com/coreos/pkg/progressutil is used in place of ioprogress to
draw the progress bars.