### PR TITLE
lib/internal/backend/repository: check if closer is nil before closing

### DIFF
--- a/lib/internal/backend/repository/repository2.go
+++ b/lib/internal/backend/repository/repository2.go
@@ -125,7 +125,9 @@ func (rb *RepositoryBackend) buildACIV2(layerIDs []string, dockerURL *types.Pars
 		return nil, nil, err
 	}
 	for _, closer := range closers {
-		closer.Close()
+		if closer != nil {
+			closer.Close()
+		}
 	}
 	for _, errChan := range errChannels {
 		err := <-errChan


### PR DESCRIPTION
If any layers being fetched encountered an error, that won't be caught
by the main goroutine until after it's attempted to close all of the
HTTP bodies, but if there was an error the body could be nil. The bodies
should be closed before checking for errors, as there may be some valid
connections, but each body should only be closed if it's not nil.

This commit adds that nil check.

Fixes (at least when I run the test locally) https://semaphoreci.com/coreos/rkt/branches/pull-request-2691/builds/3

cc @iaguis 