### PR TITLE
Split --insecure flag in two

### DIFF
--- a/lib/common/common.go
+++ b/lib/common/common.go
@@ -44,6 +44,12 @@ type ErrSeveralImages struct {
 	Images []string
 }
 
+// InsecureConfig represents the different insecure options available
+type InsecureConfig struct {
+	SkipVerify bool
+	AllowHTTP  bool
+}
+
 func (e *ErrSeveralImages) Error() string {
 	return e.Msg
 }

--- a/lib/docker2aci.go
+++ b/lib/docker2aci.go
@@ -53,9 +53,9 @@ type CommonConfig struct {
 // converting Docker images.
 type RemoteConfig struct {
 	CommonConfig
-	Username string // username to use if the image to convert needs authentication
-	Password string // password to use if the image to convert needs authentication
-	Insecure bool   // allow converting from insecure repos
+	Username string                // username to use if the image to convert needs authentication
+	Password string                // password to use if the image to convert needs authentication
+	Insecure common.InsecureConfig // Insecure options
 }
 
 // FileConfig represents the saved file specific configuration for converting

--- a/lib/internal/backend/repository/repository.go
+++ b/lib/internal/backend/repository/repository.go
@@ -42,14 +42,14 @@ type RepositoryBackend struct {
 	repoData          *RepoData
 	username          string
 	password          string
-	insecure          bool
+	insecure          common.InsecureConfig
 	hostsV2Support    map[string]bool
 	hostsV2AuthTokens map[string]map[string]string
 	schema            string
 	imageManifests    map[types.ParsedDockerURL]v2Manifest
 }
 
-func NewRepositoryBackend(username string, password string, insecure bool) *RepositoryBackend {
+func NewRepositoryBackend(username string, password string, insecure common.InsecureConfig) *RepositoryBackend {
 	return &RepositoryBackend{
 		username:          username,
 		password:          password,
@@ -137,7 +137,7 @@ func (rb *RepositoryBackend) supportsRegistry(indexURL string, version registryV
 
 		rb.setBasicAuth(req)
 
-		client := util.GetTLSClient(rb.insecure)
+		client := util.GetTLSClient(rb.insecure.SkipVerify)
 		res, err = client.Do(req)
 		return
 	}
@@ -149,7 +149,7 @@ func (rb *RepositoryBackend) supportsRegistry(indexURL string, version registryV
 		defer res.Body.Close()
 	}
 	if err != nil || !ok {
-		if rb.insecure {
+		if rb.insecure.AllowHTTP {
 			schema = "http"
 			res, err = fetch(schema)
 			if err == nil {

--- a/lib/internal/backend/repository/repository1.go
+++ b/lib/internal/backend/repository/repository1.go
@@ -29,6 +29,7 @@ import (
 	"github.com/appc/docker2aci/lib/common"
 	"github.com/appc/docker2aci/lib/internal"
 	"github.com/appc/docker2aci/lib/internal/types"
+	"github.com/appc/docker2aci/lib/internal/util"
 	"github.com/appc/docker2aci/pkg/log"
 	"github.com/appc/spec/schema"
 	"github.com/coreos/ioprogress"
@@ -133,7 +134,7 @@ func (rb *RepositoryBackend) buildACIV1(layerIDs []string, dockerURL *types.Pars
 }
 
 func (rb *RepositoryBackend) getRepoDataV1(indexURL string, remote string) (*RepoData, error) {
-	client := &http.Client{}
+	client := util.GetTLSClient(rb.insecure.SkipVerify)
 	repositoryURL := rb.schema + path.Join(indexURL, "v1", "repositories", remote, "images")
 
 	req, err := http.NewRequest("GET", repositoryURL, nil)
@@ -183,7 +184,7 @@ func (rb *RepositoryBackend) getRepoDataV1(indexURL string, remote string) (*Rep
 }
 
 func (rb *RepositoryBackend) getImageIDFromTagV1(registry string, appName string, tag string, repoData *RepoData) (string, error) {
-	client := &http.Client{}
+	client := util.GetTLSClient(rb.insecure.SkipVerify)
 	// we get all the tags instead of directly getting the imageID of the
 	// requested one (.../tags/TAG) because even though it's specified in the
 	// Docker API, some registries (e.g. Google Container Registry) don't
@@ -226,7 +227,7 @@ func (rb *RepositoryBackend) getImageIDFromTagV1(registry string, appName string
 }
 
 func (rb *RepositoryBackend) getAncestryV1(imgID, registry string, repoData *RepoData) ([]string, error) {
-	client := &http.Client{}
+	client := util.GetTLSClient(rb.insecure.SkipVerify)
 	req, err := http.NewRequest("GET", rb.schema+path.Join(registry, "images", imgID, "ancestry"), nil)
 	if err != nil {
 		return nil, err
@@ -259,7 +260,7 @@ func (rb *RepositoryBackend) getAncestryV1(imgID, registry string, repoData *Rep
 }
 
 func (rb *RepositoryBackend) getJsonV1(imgID, registry string, repoData *RepoData) ([]byte, int64, error) {
-	client := &http.Client{}
+	client := util.GetTLSClient(rb.insecure.SkipVerify)
 	req, err := http.NewRequest("GET", rb.schema+path.Join(registry, "images", imgID, "json"), nil)
 	if err != nil {
 		return nil, -1, err
@@ -294,7 +295,7 @@ func (rb *RepositoryBackend) getJsonV1(imgID, registry string, repoData *RepoDat
 }
 
 func (rb *RepositoryBackend) getLayerV1(imgID, registry string, repoData *RepoData, imgSize int64, tmpDir string) (*os.File, error) {
-	client := &http.Client{}
+	client := util.GetTLSClient(rb.insecure.SkipVerify)
 	req, err := http.NewRequest("GET", rb.schema+path.Join(registry, "images", imgID, "layer"), nil)
 	if err != nil {
 		return nil, err

--- a/lib/internal/backend/repository/repository2.go
+++ b/lib/internal/backend/repository/repository2.go
@@ -348,7 +348,7 @@ func (rb *RepositoryBackend) makeRequest(req *http.Request, repo string) (*http.
 		}
 	}
 
-	client := util.GetTLSClient(rb.insecure)
+	client := util.GetTLSClient(rb.insecure.SkipVerify)
 	res, err := client.Do(req)
 	if err != nil {
 		return nil, err

--- a/main.go
+++ b/main.go
@@ -30,19 +30,21 @@ import (
 )
 
 var (
-	flagNoSquash    bool
-	flagImage       string
-	flagDebug       bool
-	flagInsecure    bool
-	flagCompression string
-	flagVersion     bool
+	flagNoSquash           bool
+	flagImage              string
+	flagDebug              bool
+	flagInsecureSkipVerify bool
+	flagInsecureAllowHTTP  bool
+	flagCompression        string
+	flagVersion            bool
 )
 
 func init() {
 	flag.BoolVar(&flagNoSquash, "nosquash", false, "Don't squash layers and output every layer as ACI")
 	flag.StringVar(&flagImage, "image", "", "When converting a local file, it selects a particular image to convert. Format: IMAGE_NAME[:TAG]")
 	flag.BoolVar(&flagDebug, "debug", false, "Enables debug messages")
-	flag.BoolVar(&flagInsecure, "insecure", false, "Uses unencrypted connections when fetching images")
+	flag.BoolVar(&flagInsecureSkipVerify, "insecure-skip-verify", false, "Don't verify certificates when fetching images")
+	flag.BoolVar(&flagInsecureAllowHTTP, "insecure-allow-http", false, "Uses unencrypted connections when fetching images")
 	flag.StringVar(&flagCompression, "compression", "gzip", "Type of compression to use; allowed values: gzip, none")
 	flag.BoolVar(&flagVersion, "version", false, "Print version")
 }
@@ -99,7 +101,10 @@ func runDocker2ACI(arg string) error {
 			CommonConfig: cfg,
 			Username:     username,
 			Password:     password,
-			Insecure:     flagInsecure,
+			Insecure: common.InsecureConfig{
+				SkipVerify: flagInsecureSkipVerify,
+				AllowHTTP:  flagInsecureAllowHTTP,
+			},
 		}
 
 		aciLayerPaths, err = docker2aci.ConvertRemoteRepo(dockerURL, remoteConfig)


### PR DESCRIPTION
--insecure flag is removed as it was ambiguous

Two flags are added to replace it:
--insecure-skip-verify: Don't verify certificates when fetching images
--insecure-allow-http: Allows to use unencrypted connections when
fetching images

It solves existing related issues with insecure docker v1 registries

Continuation of #109 and #155, probably related with #144.