### PR TITLE
lib/repository2: use new progressutil interface

### DIFF
--- a/Godeps/Godeps.json
+++ b/Godeps/Godeps.json
@@ -1,7 +1,7 @@
 {
 	"ImportPath": "github.com/appc/docker2aci",
 	"GoVersion": "go1.6",
-	"GodepVersion": "v68",
+	"GodepVersion": "v72",
 	"Deps": [
 		{
 			"ImportPath": "github.com/appc/spec/aci",
@@ -48,8 +48,8 @@
 		},
 		{
 			"ImportPath": "github.com/coreos/pkg/progressutil",
-			"Comment": "v1",
-			"Rev": "160ae6282d8c48a33d8c150e4e4817fdef8a5cde"
+			"Comment": "v2",
+			"Rev": "7f080b6c11ac2d2347c3cd7521e810207ea1a041"
 		},
 		{
 			"ImportPath": "github.com/docker/distribution/digest",

--- a/lib/internal/backend/repository/repository2.go
+++ b/lib/internal/backend/repository/repository2.go
@@ -77,7 +77,7 @@ func (rb *RepositoryBackend) buildACIV2(layerIDs []string, dockerURL *types.Pars
 	}
 	defer os.RemoveAll(tmpParentDir)
 
-	copier := &progressutil.CopyProgressPrinter{}
+	copier := progressutil.NewCopyProgressPrinter()
 
 	var errChannels []chan error
 	closers := make([]io.ReadCloser, len(layerIDs))
@@ -339,7 +339,10 @@ func (rb *RepositoryBackend) getLayerV2(layerID string, dockerURL *types.ParsedD
 		return nil, nil, err
 	}
 
-	copier.AddCopy(in, name, size, layerFile)
+	err = copier.AddCopy(in, name, size, layerFile)
+	if err != nil {
+		return nil, nil, err
+	}
 
 	return layerFile, res.Body, nil
 }


### PR DESCRIPTION
This bumps github.com/coreos/pkg/progressutil to v2, fixing the races from https://github.com/coreos/pkg/pull/64.

