### PR TITLE
backend/repository2: don't ignore when there's an image digest

### DIFF
--- a/lib/internal/backend/repository/repository2.go
+++ b/lib/internal/backend/repository/repository2.go
@@ -161,7 +161,13 @@ func (rb *RepositoryBackend) buildACIV2(layerIDs []string, dockerURL *types.Pars
 }
 
 func (rb *RepositoryBackend) getManifestV2(dockerURL *types.ParsedDockerURL) (*v2Manifest, []string, error) {
-	url := rb.schema + path.Join(dockerURL.IndexURL, "v2", dockerURL.ImageName, "manifests", dockerURL.Tag)
+	var reference string
+	if dockerURL.Digest != "" {
+		reference = dockerURL.Digest
+	} else {
+		reference = dockerURL.Tag
+	}
+	url := rb.schema + path.Join(dockerURL.IndexURL, "v2", dockerURL.ImageName, "manifests", reference)
 
 	req, err := http.NewRequest("GET", url, nil)
 	if err != nil {


### PR DESCRIPTION
The code for pulling from a v2 repository always used the tag to pull,
but the correct action was to pull by digest when one was specified.

Related: https://github.com/appc/docker2aci/issues/170.