### PR TITLE
avoid O(N) and fix defer reader close

### DIFF
--- a/lib/internal/backend/repository/repository.go
+++ b/lib/internal/backend/repository/repository.go
@@ -50,6 +50,7 @@ type RepositoryBackend struct {
 	imageManifests    map[types.ParsedDockerURL]v2Manifest
 	imageV2Manifests  map[types.ParsedDockerURL]*typesV2.ImageManifest
 	imageConfigs      map[types.ParsedDockerURL]*typesV2.ImageConfig
+	reverseLayers     map[string]int
 }
 
 func NewRepositoryBackend(username string, password string, insecure common.InsecureConfig) *RepositoryBackend {
@@ -62,6 +63,7 @@ func NewRepositoryBackend(username string, password string, insecure common.Inse
 		imageManifests:    make(map[types.ParsedDockerURL]v2Manifest),
 		imageV2Manifests:  make(map[types.ParsedDockerURL]*typesV2.ImageManifest),
 		imageConfigs:      make(map[types.ParsedDockerURL]*typesV2.ImageConfig),
+		reverseLayers:     make(map[string]int),
 	}
 }
 


### PR DESCRIPTION
- First commit deals with an O(N) routine and removes it (the last layer ID index takes N-1 cycle to be found)
- Second commit remove a reader close call because the reader is used after the function returns