### PR TITLE
tests: added golang tests to lib/tests to test image fetching

### DIFF
--- a/lib/internal/internal.go
+++ b/lib/internal/internal.go
@@ -82,7 +82,11 @@ func GenerateACI(layerNumber int, layerData types.DockerImageData, dockerURL *ty
 func GenerateACI22LowerLayer(dockerURL *types.ParsedDockerURL, layerDigest string, outputDir string, layerFile *os.File, curPwl []string, compression common.Compression) (string, *schema.ImageManifest, error) {
 	formattedDigest := strings.Replace(layerDigest, ":", "-", -1)
 	aciName := fmt.Sprintf("%s/%s-%s", dockerURL.IndexURL, dockerURL.ImageName, formattedDigest)
-	manifest, err := GenerateEmptyManifest(aciName)
+	sanitizedAciName, err := appctypes.SanitizeACIdentifier(aciName)
+	if err != nil {
+		return "", nil, err
+	}
+	manifest, err := GenerateEmptyManifest(sanitizedAciName)
 	if err != nil {
 		return "", nil, err
 	}
@@ -101,8 +105,12 @@ func GenerateACI22LowerLayer(dockerURL *types.ParsedDockerURL, layerDigest strin
 }
 
 func GenerateACI22TopLayer(dockerURL *types.ParsedDockerURL, imageConfig *typesV2.ImageConfig, layerDigest string, outputDir string, layerFile *os.File, curPwl []string, compression common.Compression, lowerLayers []*schema.ImageManifest) (string, *schema.ImageManifest, error) {
-	aciName := fmt.Sprintf("%s/%s", dockerURL.IndexURL, dockerURL.ImageName)
-	manifest, err := GenerateManifestV22(aciName, dockerURL, imageConfig, layerDigest, lowerLayers)
+	aciName := fmt.Sprintf("%s/%s-%s", dockerURL.IndexURL, dockerURL.ImageName, layerDigest)
+	sanitizedAciName, err := appctypes.SanitizeACIdentifier(aciName)
+	if err != nil {
+		return "", nil, err
+	}
+	manifest, err := GenerateManifestV22(sanitizedAciName, dockerURL, imageConfig, layerDigest, lowerLayers)
 	if err != nil {
 		return "", nil, err
 	}

--- a/lib/tests/common.go
+++ b/lib/tests/common.go
@@ -1,0 +1,138 @@
+package test
+
+import (
+	"archive/tar"
+	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"io/ioutil"
+	"os"
+	"path"
+
+	"github.com/appc/docker2aci/lib/internal/typesV2"
+)
+
+type Layer map[*tar.Header][]byte
+
+type Docker22Image struct {
+	RepoTags []string
+	Layers   []Layer
+	Config   typesV2.ImageConfig
+}
+
+func GenerateDocker22(destPath string, img Docker22Image) error {
+	layerHashes, err := GenLayers(destPath, img.Layers)
+	if err != nil {
+		return err
+	}
+	configHash, err := GenDocker22Config(destPath, img.Config, layerHashes)
+	if err != nil {
+		return err
+	}
+	err = GenDocker22Manifest(destPath, configHash, layerHashes)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func GenLayers(destPath string, layers []Layer) ([]string, error) {
+	var layerHashes []string
+	for _, l := range layers {
+		layerBuffer := &bytes.Buffer{}
+		tw := tar.NewWriter(layerBuffer)
+		for hdr, contents := range l {
+			hdr.Size = int64(len(contents))
+			err := tw.WriteHeader(hdr)
+			if err != nil {
+				tw.Close()
+				return nil, err
+			}
+			_, err = tw.Write(contents)
+			if err != nil {
+				tw.Close()
+				return nil, err
+			}
+		}
+		tw.Close()
+		layerTarBlob := layerBuffer.Bytes()
+		h := sha256.New()
+		h.Write(layerTarBlob)
+		hashStr := hex.EncodeToString(h.Sum(nil))
+		layerHashes = append(layerHashes, hashStr)
+		err := ioutil.WriteFile(path.Join(destPath, hashStr), layerTarBlob, 0644)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return layerHashes, nil
+}
+
+func GenDocker22Config(destPath string, conf typesV2.ImageConfig, layerHashes []string) (string, error) {
+	conf.RootFS = &typesV2.ImageConfigRootFS{}
+	conf.RootFS.Type = "layers"
+	for _, h := range layerHashes {
+		conf.RootFS.DiffIDs = append(conf.RootFS.DiffIDs, "sha256:"+h)
+	}
+	confblob, err := json.Marshal(conf)
+	if err != nil {
+		return "", err
+	}
+	h := sha256.New()
+	h.Write(confblob)
+	hashStr := hex.EncodeToString(h.Sum(nil))
+	err = ioutil.WriteFile(path.Join(destPath, hashStr), confblob, 0644)
+	if err != nil {
+		return "", err
+	}
+	return hashStr, nil
+}
+
+func GenDocker22Manifest(destPath, configHash string, layerHashes []string) error {
+	getDigestSize := func(digest string) (int64, error) {
+		fi, err := os.Stat(path.Join(destPath, digest))
+		if err != nil {
+			return 0, err
+		}
+		return fi.Size(), nil
+	}
+
+	configSize, err := getDigestSize(configHash)
+	if err != nil {
+		return err
+	}
+
+	manifest := &typesV2.ImageManifest{
+		SchemaVersion: 2,
+		MediaType:     typesV2.MediaTypeDockerV22Manifest,
+		Config: &typesV2.ImageManifestDigest{
+			MediaType: typesV2.MediaTypeDockerV22Config,
+			Size:      int(configSize),
+			Digest:    "sha256:" + configHash,
+		},
+	}
+	for _, h := range layerHashes {
+		layerSize, err := getDigestSize(h)
+		if err != nil {
+			return err
+		}
+		manifest.Layers = append(manifest.Layers,
+			&typesV2.ImageManifestDigest{
+				MediaType: typesV2.MediaTypeDockerV22RootFS,
+				Size:      int(layerSize),
+				Digest:    "sha256:" + h,
+			})
+	}
+
+	manblob, err := json.Marshal(manifest)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile(path.Join(destPath, "manifest.json"), manblob, 0644)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/lib/tests/server.go
+++ b/lib/tests/server.go
@@ -1,0 +1,113 @@
+package test
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path"
+	"strings"
+	"testing"
+)
+
+func RunDockerRegistry(t *testing.T, imgPath, imgName, imgRef, manifestMediaType string) *httptest.Server {
+	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Logf("path requested: %s", r.URL.Path)
+		if r.URL.Path == "/v2" {
+			w.Header().Add("Docker-Distribution-API-Version", "registry/2.0")
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		if strings.Contains(r.URL.Path, "manifests") {
+			GetManifest(t, w, r, imgPath, imgName, imgRef, manifestMediaType)
+			return
+		}
+		if strings.Contains(r.URL.Path, "blobs") {
+			GetBlob(t, w, r, imgPath, imgName, imgRef)
+			return
+		}
+		t.Errorf("invalid path: %s", r.URL.Path)
+	})
+	server := httptest.NewServer(handler)
+	return server
+}
+
+func GetManifest(t *testing.T, w http.ResponseWriter, r *http.Request, imgPath, imgName, imgRef, manifestMediaType string) {
+	parsedImgName, parsedRef, err := parseURL("manifests", r.URL.Path)
+	if err != nil {
+		w.WriteHeader(http.StatusNotFound)
+		t.Errorf("get manifest: error parsing path: %v", err)
+		return
+	}
+	if parsedImgName != imgName {
+		w.WriteHeader(http.StatusNotFound)
+		t.Errorf("get manifest: invalid image name requested: %q", parsedImgName)
+		return
+	}
+	if parsedRef != imgRef {
+		w.WriteHeader(http.StatusNotFound)
+		t.Errorf("get manifest: invalid image ref requested: %q", parsedImgName)
+		return
+	}
+	manFile, err := os.Open(path.Join(imgPath, "manifest.json"))
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		t.Errorf("get manifest: couldn't open manifest: %v", err)
+		return
+	}
+	defer manFile.Close()
+	w.Header().Add("content-type", manifestMediaType)
+	_, err = io.Copy(w, manFile)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		t.Errorf("get manifest: couldn't copy manifest: %v", err)
+		return
+	}
+}
+
+func GetBlob(t *testing.T, w http.ResponseWriter, r *http.Request, imgPath, imgName, imgRef string) {
+	parsedImgName, digest, err := parseURL("blobs", r.URL.Path)
+	if err != nil {
+		w.WriteHeader(http.StatusNotFound)
+		t.Errorf("get blob: %v", err)
+		return
+	}
+	digest = strings.TrimPrefix(digest, "sha256:")
+	if parsedImgName != imgName {
+		w.WriteHeader(http.StatusNotFound)
+		t.Errorf("get blob: invalid image name requested: %s", parsedImgName)
+		return
+	}
+	blobFile, err := os.Open(path.Join(imgPath, digest))
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		t.Errorf("get blob: couldn't open manifest: %v", err)
+		return
+	}
+	defer blobFile.Close()
+	_, err = io.Copy(w, blobFile)
+	if err != nil {
+		w.WriteHeader(http.StatusInternalServerError)
+		t.Errorf("get blob: couldn't copy manifest: %v", err)
+		return
+	}
+}
+
+func parseURL(resource, input string) (string, string, error) {
+	tokens := strings.Split(input, "/")
+	tokLen := len(tokens)
+	if tokLen < 5 {
+		return "", "", fmt.Errorf("invalid number of tokens in path: %d", len(tokens))
+	}
+	if tokens[0] != "" {
+		return "", "", fmt.Errorf("path parse error: tok0 = %s", tokens[0])
+	}
+	if tokens[1] != "v2" {
+		return "", "", fmt.Errorf("path parse error: tok1 = %s", tokens[1])
+	}
+	if tokens[tokLen-2] != resource {
+		return "", "", fmt.Errorf("path parse error: tok-2 = %s", tokens[tokLen-2])
+	}
+	return path.Join(tokens[2 : tokLen-2]...), tokens[tokLen-1], nil
+}

--- a/lib/tests/v22_test.go
+++ b/lib/tests/v22_test.go
@@ -1,0 +1,192 @@
+package test
+
+import (
+	"testing"
+
+	"archive/tar"
+	"io/ioutil"
+	"os"
+	"path"
+	"strings"
+	"time"
+
+	docker2aci "github.com/appc/docker2aci/lib"
+	d2acommon "github.com/appc/docker2aci/lib/common"
+	"github.com/appc/docker2aci/lib/internal/typesV2"
+)
+
+func newDocker22Image(layers []Layer) Docker22Image {
+	return Docker22Image{
+		RepoTags: []string{"testimage:latest"},
+		Layers:   layers,
+		Config: typesV2.ImageConfig{
+			Created:      "2016-06-02T21:43:31.291506236Z",
+			Author:       "rkt developer <rkt-dev@googlegroups.com>",
+			Architecture: "amd64",
+			OS:           "linux",
+			Config: &typesV2.ImageConfigConfig{
+				User:       "",
+				Memory:     12345,
+				MemorySwap: 0,
+				CpuShares:  9001,
+				ExposedPorts: map[string]struct{}{
+					"80": struct{}{},
+				},
+				Env: []string{
+					"FOO=1",
+					"BAR=2",
+				},
+				Entrypoint: nil,
+				Cmd:        nil,
+				Volumes:    nil,
+				WorkingDir: "/",
+			},
+		},
+	}
+}
+
+func fetchImage(imgName, outputDir string, squash bool) ([]string, error) {
+	conversionTmpDir, err := ioutil.TempDir("", "docker2aci-test-")
+	if err != nil {
+		return nil, err
+	}
+	defer os.RemoveAll(conversionTmpDir)
+
+	conf := docker2aci.RemoteConfig{
+		CommonConfig: docker2aci.CommonConfig{
+			Squash:      squash,
+			OutputDir:   outputDir,
+			TmpDir:      conversionTmpDir,
+			Compression: d2acommon.GzipCompression,
+		},
+		Username: "",
+		Password: "",
+		Insecure: d2acommon.InsecureConfig{
+			SkipVerify: true,
+			AllowHTTP:  true,
+		},
+	}
+
+	return docker2aci.ConvertRemoteRepo(imgName, conf)
+}
+
+func TestFetchingByTagV22(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "docker2aci-test-")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	layers := []Layer{
+		Layer{
+			&tar.Header{
+				Name:    "thisisafile",
+				Mode:    0644,
+				ModTime: time.Now(),
+			}: []byte("these are its contents"),
+		},
+	}
+	err = GenerateDocker22(tmpDir, newDocker22Image(layers))
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	imgName := "docker2aci/dockerv22test"
+	imgRef := "v0.1.0"
+	server := RunDockerRegistry(t, tmpDir, imgName, imgRef, typesV2.MediaTypeDockerV22Manifest)
+	defer server.Close()
+
+	localUrl := path.Join(strings.TrimPrefix(server.URL, "http://"), imgName) + ":" + imgRef
+
+	outputDir, err := ioutil.TempDir("", "docker2aci-test-")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	defer os.RemoveAll(outputDir)
+
+	_, err = fetchImage(localUrl, outputDir, true)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func TestFetchingByDigestV22(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "docker2aci-test-")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	layers := []Layer{
+		Layer{
+			&tar.Header{
+				Name:    "thisisafile",
+				Mode:    0644,
+				ModTime: time.Now(),
+			}: []byte("these are its contents"),
+		},
+	}
+	err = GenerateDocker22(tmpDir, newDocker22Image(layers))
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	imgName := "docker2aci/dockerv22test"
+	imgRef := "sha256:45b23dee08af5e43a7fea6c4cf9c25ccf269ee113168c19722f87876677c5cb2"
+	server := RunDockerRegistry(t, tmpDir, imgName, imgRef, typesV2.MediaTypeDockerV22Manifest)
+	defer server.Close()
+
+	localUrl := path.Join(strings.TrimPrefix(server.URL, "http://"), imgName) + "@" + imgRef
+
+	outputDir, err := ioutil.TempDir("", "docker2aci-test-")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	defer os.RemoveAll(outputDir)
+
+	_, err = fetchImage(localUrl, outputDir, true)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+}
+
+func TestFetchingMultipleLayersV22(t *testing.T) {
+	tmpDir, err := ioutil.TempDir("", "docker2aci-test-")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	defer os.RemoveAll(tmpDir)
+	layers := []Layer{
+		Layer{
+			&tar.Header{
+				Name:    "thisisafile",
+				Mode:    0644,
+				ModTime: time.Now(),
+			}: []byte("these are its contents"),
+		},
+		Layer{
+			&tar.Header{
+				Name:    "thisisadifferentfile",
+				Mode:    0644,
+				ModTime: time.Now(),
+			}: []byte("the contents of this file are different from the last!"),
+		},
+	}
+	err = GenerateDocker22(tmpDir, newDocker22Image(layers))
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	imgName := "docker2aci/dockerv22test"
+	imgRef := "v0.1.0"
+	server := RunDockerRegistry(t, tmpDir, imgName, imgRef, typesV2.MediaTypeDockerV22Manifest)
+	defer server.Close()
+
+	localUrl := path.Join(strings.TrimPrefix(server.URL, "http://"), imgName) + ":" + imgRef
+
+	outputDir, err := ioutil.TempDir("", "docker2aci-test-")
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+	defer os.RemoveAll(outputDir)
+
+	_, err = fetchImage(localUrl, outputDir, true)
+	if err != nil {
+		t.Fatalf("%v", err)
+	}
+}

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -2,6 +2,23 @@
 
 set -e
 
+# Gets the parent of the directory that this script is stored in.
+# https://stackoverflow.com/questions/59895/can-a-bash-script-tell-what-directory-its-stored-in
+DIR="$( cd "$( dirname $( dirname "${BASH_SOURCE[0]}" ) )" && pwd )"
+
+ORG_PATH="github.com/appc"
+REPO_PATH="${ORG_PATH}/docker2aci"
+
+if [ ! -h ${DIR}/gopath/src/${REPO_PATH} ]; then
+  mkdir -p ${DIR}/gopath/src/${ORG_PATH}
+  cd ${DIR} && ln -s ../../../.. gopath/src/${REPO_PATH} || exit 255
+fi
+
+export GO15VENDOREXPERIMENT=1
+export GOPATH=${DIR}/gopath
+
+go test -v ${REPO_PATH}/lib/tests
+
 DOCKER2ACI=../bin/docker2aci
 PREFIX=docker2aci-tests
 TESTDIR=$(dirname $(realpath $0))


### PR DESCRIPTION
This commit creates the directory lib/tests, which includes the
following:

 - code for generating a manifest and layers conforming to docker v2.2
 - code for emulating a docker registry that hosts these images (the
   docker daemon can successfully pull images from this)
 - a few tests that utilize these to test using the docker2aci library
   to pull/convert an image

These fetching tests triggered a panic in docker2aci, which this commit also fixes.

I intend to create a followup PR to also test the docker v2.1 logic and the logic for converting a file on disk, and to hopefully pull the logic under tests/ into these golang tests.