### PR TITLE
repository2: populate reverseLayers correctly

### DIFF
--- a/lib/internal/backend/repository/repository2.go
+++ b/lib/internal/backend/repository/repository2.go
@@ -345,7 +345,7 @@ func (rb *RepositoryBackend) getManifestV21(dockerURL *types.ParsedDockerURL, re
 	layers := make([]string, len(manifest.FSLayers))
 
 	for i, layer := range manifest.FSLayers {
-		rb.reverseLayers[layer.BlobSum] = i
+		rb.reverseLayers[layer.BlobSum] = len(manifest.FSLayers) - 1 - i
 		layers[i] = layer.BlobSum
 	}
 


### PR DESCRIPTION
In da56c93f we introduced an optimization to avoid going through all the
layers every time we need the index of a specific one.

However, when we set the layer index, we weren't setting the reversed
index, like we were doing before the optimization.

Fix it by setting the correct index.

Fixes #184 