### PR TITLE
repository2: get the correct layer index

### DIFF
--- a/lib/internal/backend/repository/repository.go
+++ b/lib/internal/backend/repository/repository.go
@@ -50,7 +50,7 @@ type RepositoryBackend struct {
 	imageManifests    map[types.ParsedDockerURL]v2Manifest
 	imageV2Manifests  map[types.ParsedDockerURL]*typesV2.ImageManifest
 	imageConfigs      map[types.ParsedDockerURL]*typesV2.ImageConfig
-	reverseLayers     map[string]int
+	layersIndex       map[string]int
 }
 
 func NewRepositoryBackend(username string, password string, insecure common.InsecureConfig) *RepositoryBackend {
@@ -63,7 +63,7 @@ func NewRepositoryBackend(username string, password string, insecure common.Inse
 		imageManifests:    make(map[types.ParsedDockerURL]v2Manifest),
 		imageV2Manifests:  make(map[types.ParsedDockerURL]*typesV2.ImageManifest),
 		imageConfigs:      make(map[types.ParsedDockerURL]*typesV2.ImageConfig),
-		reverseLayers:     make(map[string]int),
+		layersIndex:       make(map[string]int),
 	}
 }
 

--- a/lib/internal/backend/repository/repository2.go
+++ b/lib/internal/backend/repository/repository2.go
@@ -102,7 +102,7 @@ func (rb *RepositoryBackend) buildACIV21(layerIDs []string, dockerURL *types.Par
 
 			manifest := rb.imageManifests[*dockerURL]
 
-			layerIndex, ok := rb.reverseLayers[layerID]
+			layerIndex, ok := rb.layersIndex[layerID]
 			if !ok {
 				errChan <- fmt.Errorf("layer not found in manifest: %s", layerID)
 				return
@@ -345,7 +345,9 @@ func (rb *RepositoryBackend) getManifestV21(dockerURL *types.ParsedDockerURL, re
 	layers := make([]string, len(manifest.FSLayers))
 
 	for i, layer := range manifest.FSLayers {
-		rb.reverseLayers[layer.BlobSum] = len(manifest.FSLayers) - 1 - i
+		if _, ok := rb.layersIndex[layer.BlobSum]; !ok {
+			rb.layersIndex[layer.BlobSum] = i
+		}
 		layers[i] = layer.BlobSum
 	}
 


### PR DESCRIPTION
In da56c93f we introduced an optimization to avoid going through all the
layers every time we need the index of a specific one.

However, this resulted in incorrect Image Manifests being generated.

In f8e82fab we attempted to fix this. We assumed that the mistake was
that the index we used was supposed to be reversed (from the end instead
of from the beginning of the layer list). This assumption was wrong. and
was probably motivated by the name of the map (`reverseLayers`).

The problem was that there can be several layers with the same BlobSum
(layerID) but different manifest and when we populated the map, we were
storing the last one for a given BlobSum. This is not what we were doing
previously, instead we were returning the first match.

Fix this by storing the first appearance of a BlobSum. Also, change the
name of `reverseLayers` to `layersIndex`.

- [ ] Test