### PR TITLE
repository2: fix manifest v2.2 layer ordering.

### DIFF
--- a/lib/internal/backend/repository/repository2.go
+++ b/lib/internal/backend/repository/repository2.go
@@ -254,7 +254,8 @@ func (rb *RepositoryBackend) buildACIV22(layerIDs []string, dockerURL *types.Par
 	var aciLayerPaths []string
 	var aciManifests []*schema.ImageManifest
 	var curPwl []string
-	for i := len(layerIDs) - 1; i > 0; i-- {
+	var i int
+	for i = 0; i < len(layerIDs)-1; i++ {
 		log.Debug("Generating layer ACI...")
 		aciPath, aciManifest, err := internal.GenerateACI22LowerLayer(dockerURL, layerIDs[i], outputDir, layerFiles[i], curPwl, compression)
 		if err != nil {
@@ -264,7 +265,8 @@ func (rb *RepositoryBackend) buildACIV22(layerIDs []string, dockerURL *types.Par
 		aciManifests = append(aciManifests, aciManifest)
 		curPwl = aciManifest.PathWhitelist
 	}
-	aciPath, aciManifest, err := internal.GenerateACI22TopLayer(dockerURL, rb.imageConfigs[*dockerURL], layerIDs[0], outputDir, layerFiles[0], curPwl, compression, aciManifests)
+	log.Debug("Generating layer ACI...")
+	aciPath, aciManifest, err := internal.GenerateACI22TopLayer(dockerURL, rb.imageConfigs[*dockerURL], layerIDs[i], outputDir, layerFiles[i], curPwl, compression, aciManifests)
 	if err != nil {
 		return nil, nil, fmt.Errorf("error generating ACI: %v", err)
 	}


### PR DESCRIPTION
With docker manifest v2.2 and oci the layers are ordered from the base layer to
the topmost layer.

This is just a quick fix for review. Next steps will be to add tests and remove duplicated layers.

Fixes #189  