### PR TITLE
lib/internal: do not compare tag when pulling by digest

### DIFF
--- a/lib/internal/backend/repository/repository2.go
+++ b/lib/internal/backend/repository/repository2.go
@@ -334,7 +334,7 @@ func (rb *RepositoryBackend) getManifestV21(dockerURL *types.ParsedDockerURL, re
 		return nil, fmt.Errorf("name doesn't match what was requested, expected: %s, downloaded: %s", dockerURL.ImageName, manifest.Name)
 	}
 
-	if manifest.Tag != dockerURL.Tag {
+	if dockerURL.Tag != "" && manifest.Tag != dockerURL.Tag {
 		return nil, fmt.Errorf("tag doesn't match what was requested, expected: %s, downloaded: %s", dockerURL.Tag, manifest.Tag)
 	}
 

--- a/lib/internal/docker/docker_functions.go
+++ b/lib/internal/docker/docker_functions.go
@@ -140,13 +140,14 @@ func ParseDockerURL(arg string) (*types.ParsedDockerURL, error) {
 		return nil, err
 	}
 
-	tag := defaultTag
-	var digest string
+	var tag, digest string
 	switch x := r.(type) {
 	case reference.Canonical:
 		digest = x.Digest().String()
 	case reference.NamedTagged:
 		tag = x.Tag()
+	default:
+		tag = defaultTag
 	}
 
 	indexURL, remoteName := SplitReposName(r.Name())


### PR DESCRIPTION
This commit fixes docker2aci pull-by-digest in order to avoid an
improper fallback to "latest" tag and a wrong comparison when no
tags have been specified.

Reference: https://github.com/coreos/rkt/issues/2313#issuecomment-245455406