### PR TITLE
Map Docker labels to appc annotations.

### DIFF
--- a/lib/internal/internal.go
+++ b/lib/internal/internal.go
@@ -271,6 +271,10 @@ func GenerateManifest(layerData types.DockerImageData, dockerURL *types.ParsedDo
 
 			genManifest.App = app
 		}
+
+		for k, v := range dockerConfig.Labels {
+			addAnno(k, v)
+		}
 	}
 
 	if layerData.Parent != "" {

--- a/lib/internal/types/docker_types.go
+++ b/lib/internal/types/docker_types.go
@@ -62,6 +62,7 @@ type DockerImageConfig struct {
 	NetworkDisabled bool
 	MacAddress      string
 	OnBuild         []string
+	Labels          map[string]string
 }
 
 // DockerAuthConfigOld represents the deprecated ~/.dockercfg auth


### PR DESCRIPTION
Given a Dockerfile:

```
FROM scratch
LABEL foo=bar
ADD emptyfile /
```

touch emptyfile

docker build -t grep/test .

docker save -o docker/test.docker grep/test

Exported docker manifest:

```
[
  {
    "Config": "02d28b56668b4dcd4f354b2799f65246378aa23e4f5e62db4d6eb7d8737beee9.json",
    "RepoTags": [
      "grep/test:latest"
    ],
    "Layers": [
      "0e664782202308a03920d0fe133f34e6d348e0cd2cf315c24d71a1c5d8b48f6f/layer.tar"
    ]
  }
]
```

```
cat 02d28b56668b4dcd4f354b2799f65246378aa23e4f5e62db4d6eb7d8737beee9.json | jq .config
{
  "Hostname": "9cfcce2510b1",
  "Domainname": "",
  "User": "",
  "AttachStdin": false,
  "AttachStdout": false,
  "AttachStderr": false,
  "Tty": false,
  "OpenStdin": false,
  "StdinOnce": false,
  "Env": [
    "PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
  ],
  "Cmd": null,
  "Image": "sha256:dc7cef81fee136961f5302ddd013a29aaf0a3f04e0dfc2208ed8a53d34bacb8b",
  "Volumes": null,
  "WorkingDir": "",
  "Entrypoint": null,
  "OnBuild": null,
  "Labels": {
    "foo": "bar"
  }
}
```

docker2aci test.docker

tar xvf grep-test-latest.aci

```
cat manifest | jq .annotations
[
  {
    "name": "created",
    "value": "2016-10-06T20:34:17Z"
  },
  {
    "name": "appc.io/docker/repository",
    "value": "grep/test"
  },
  {
    "name": "appc.io/docker/imageid",
    "value": "0e664782202308a03920d0fe133f34e6d348e0cd2cf315c24d71a1c5d8b48f6f"
  },
  {
    "name": "foo",
    "value": "bar"
  }
]
```
