### PR TITLE
lib/internal: fix vet errors, and error handling

### DIFF
--- a/lib/internal/backend/file/file.go
+++ b/lib/internal/backend/file/file.go
@@ -364,7 +364,7 @@ func getJsonV22(file *os.File, layerID string) ([]byte, error) {
 func getTarFileBytes(file *os.File, path string) ([]byte, error) {
 	_, err := file.Seek(0, 0)
 	if err != nil {
-		fmt.Errorf("error seeking file: %v", err)
+		return nil, fmt.Errorf("error seeking file: %v", err)
 	}
 
 	var fileBytes []byte
@@ -395,7 +395,7 @@ func extractEmbeddedLayer(file *os.File, layerTarPath string, outputPath string)
 	log.Info("Extracting ", layerTarPath, "\n")
 	_, err := file.Seek(0, 0)
 	if err != nil {
-		fmt.Errorf("error seeking file: %v", err)
+		return nil, fmt.Errorf("error seeking file: %v", err)
 	}
 
 	var layerFile *os.File

--- a/lib/internal/internal.go
+++ b/lib/internal/internal.go
@@ -309,20 +309,22 @@ func GenerateEmptyManifest(name string) (*schema.ImageManifest, error) {
 		return nil, err
 	}
 
+	labels := appctypes.Labels{
+		appctypes.Label{
+			Name:  *appctypes.MustACIdentifier("arch"),
+			Value: runtime.GOARCH,
+		},
+		appctypes.Label{
+			Name:  *appctypes.MustACIdentifier("os"),
+			Value: runtime.GOOS,
+		},
+	}
+
 	return &schema.ImageManifest{
 		ACKind:    schema.ImageManifestKind,
 		ACVersion: schema.AppContainerVersion,
 		Name:      *acid,
-		Labels: appctypes.Labels{
-			appctypes.Label{
-				*appctypes.MustACIdentifier("arch"),
-				runtime.GOARCH,
-			},
-			appctypes.Label{
-				*appctypes.MustACIdentifier("os"),
-				runtime.GOOS,
-			},
-		},
+		Labels:    labels,
 	}, nil
 }
 

--- a/lib/tests/v22_test.go
+++ b/lib/tests/v22_test.go
@@ -55,16 +55,16 @@ var expectedImageManifest = schema.ImageManifest{
 	Name:      *types.MustACIdentifier("variant"),
 	Labels: []types.Label{
 		types.Label{
-			*types.MustACIdentifier("arch"),
-			"amd64",
+			Name:  *types.MustACIdentifier("arch"),
+			Value: "amd64",
 		},
 		types.Label{
-			*types.MustACIdentifier("os"),
-			"linux",
+			Name:  *types.MustACIdentifier("os"),
+			Value: "linux",
 		},
 		types.Label{
-			*types.MustACIdentifier("version"),
-			"v0.1.0",
+			Name:  *types.MustACIdentifier("version"),
+			Value: "v0.1.0",
 		},
 	},
 	App: &types.App{
@@ -221,7 +221,7 @@ func manifestEqual(manifest, expected *schema.ImageManifest) error {
 		return fmt.Errorf("expected ACVersion %q, got %q", expected.ACVersion, manifest.ACVersion)
 	}
 	if !reflect.DeepEqual(*manifest.App, *expected.App) {
-		return fmt.Errorf("expected App %q, got %q", *expected.App, *manifest.App)
+		return fmt.Errorf("expected App %v, got %v", *expected.App, *manifest.App)
 	}
 	for _, label := range []string{"arch", "os", "version"} {
 		if err := checkLabel(label, manifest, expected); err != nil {

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -17,6 +17,8 @@ fi
 export GO15VENDOREXPERIMENT=1
 export GOPATH=${DIR}/gopath
 
+go vet ./pkg/...
+go vet ./lib/...
 go test -v ${REPO_PATH}/lib/tests
 
 DOCKER2ACI=../bin/docker2aci


### PR DESCRIPTION
This introduces go vet, and fixes error handling in backend/file.

Fixes #194