### PR TITLE
lib/internal: fix vet errors, and error handling

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -30,4 +30,6 @@ if [ "${GOOS}" = "freebsd" ]; then
 fi
 
 echo "Building docker2aci..."
+go vet ./pkg/...
+go vet ./lib/...
 go build -o ${GOBIN}/docker2aci -ldflags "${GLDFLAGS}" ${REPO_PATH}

--- a/lib/internal/backend/file/file.go
+++ b/lib/internal/backend/file/file.go
@@ -364,7 +364,7 @@ func getJsonV22(file *os.File, layerID string) ([]byte, error) {
 func getTarFileBytes(file *os.File, path string) ([]byte, error) {
 	_, err := file.Seek(0, 0)
 	if err != nil {
-		fmt.Errorf("error seeking file: %v", err)
+		return nil, fmt.Errorf("error seeking file: %v", err)
 	}
 
 	var fileBytes []byte
@@ -395,7 +395,7 @@ func extractEmbeddedLayer(file *os.File, layerTarPath string, outputPath string)
 	log.Info("Extracting ", layerTarPath, "\n")
 	_, err := file.Seek(0, 0)
 	if err != nil {
-		fmt.Errorf("error seeking file: %v", err)
+		return nil, fmt.Errorf("error seeking file: %v", err)
 	}
 
 	var layerFile *os.File

--- a/lib/internal/internal.go
+++ b/lib/internal/internal.go
@@ -315,12 +315,12 @@ func GenerateEmptyManifest(name string) (*schema.ImageManifest, error) {
 		Name:      *acid,
 		Labels: appctypes.Labels{
 			appctypes.Label{
-				*appctypes.MustACIdentifier("arch"),
-				runtime.GOARCH,
+				Name:  *appctypes.MustACIdentifier("arch"),
+				Value: runtime.GOARCH,
 			},
 			appctypes.Label{
-				*appctypes.MustACIdentifier("os"),
-				runtime.GOOS,
+				Name:  *appctypes.MustACIdentifier("os"),
+				Value: runtime.GOOS,
 			},
 		},
 	}, nil

--- a/lib/tests/v22_test.go
+++ b/lib/tests/v22_test.go
@@ -55,16 +55,16 @@ var expectedImageManifest = schema.ImageManifest{
 	Name:      *types.MustACIdentifier("variant"),
 	Labels: []types.Label{
 		types.Label{
-			*types.MustACIdentifier("arch"),
-			"amd64",
+			Name:  *types.MustACIdentifier("arch"),
+			Value: "amd64",
 		},
 		types.Label{
-			*types.MustACIdentifier("os"),
-			"linux",
+			Name:  *types.MustACIdentifier("os"),
+			Value: "linux",
 		},
 		types.Label{
-			*types.MustACIdentifier("version"),
-			"v0.1.0",
+			Name:  *types.MustACIdentifier("version"),
+			Value: "v0.1.0",
 		},
 	},
 	App: &types.App{
@@ -221,7 +221,7 @@ func manifestEqual(manifest, expected *schema.ImageManifest) error {
 		return fmt.Errorf("expected ACVersion %q, got %q", expected.ACVersion, manifest.ACVersion)
 	}
 	if !reflect.DeepEqual(*manifest.App, *expected.App) {
-		return fmt.Errorf("expected App %q, got %q", *expected.App, *manifest.App)
+		return fmt.Errorf("expected App %v, got %v", *expected.App, *manifest.App)
 	}
 	for _, label := range []string{"arch", "os", "version"} {
 		if err := checkLabel(label, manifest, expected); err != nil {


### PR DESCRIPTION
This introduces go vet, and fixes error handling in backend/file.

Fixes #194