### PR TITLE
Correct v2 registry check URL

### DIFF
--- a/lib/internal/backend/repository/repository.go
+++ b/lib/internal/backend/repository/repository.go
@@ -22,7 +22,7 @@ package repository
 import (
 	"fmt"
 	"net/http"
-	"path"
+	"net/url"
 
 	"github.com/appc/docker2aci/lib/common"
 	"github.com/appc/docker2aci/lib/internal/docker"
@@ -130,13 +130,12 @@ func (rb *RepositoryBackend) supportsRegistry(indexURL string, version registryV
 	case registryV1:
 		URLPath = "v1/_ping"
 	case registryV2:
-		URLPath = "v2"
+		URLPath = "v2/"
 	}
-	URLStr := path.Join(indexURL, URLPath)
 
 	fetch := func(schema string) (res *http.Response, err error) {
-		url := schema + "://" + URLStr
-		req, err := http.NewRequest("GET", url, nil)
+		u := url.URL{Scheme: schema, Host: indexURL, Path: URLPath}
+		req, err := http.NewRequest("GET", u.String(), nil)
 		if err != nil {
 			return nil, err
 		}

--- a/lib/tests/server.go
+++ b/lib/tests/server.go
@@ -14,7 +14,7 @@ import (
 func RunDockerRegistry(t *testing.T, imgPath, imgName, imgRef, manifestMediaType string) *httptest.Server {
 	handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		t.Logf("path requested: %s", r.URL.Path)
-		if r.URL.Path == "/v2" {
+		if r.URL.Path == "/v2/" {
 			w.Header().Add("Docker-Distribution-API-Version", "registry/2.0")
 			w.WriteHeader(http.StatusOK)
 			return


### PR DESCRIPTION
fixes #219
requires a trailing / on the v2 check URL
https://docs.docker.com/registry/spec/api/#api-version-check
some implementations are clearly stricter with the specs
https://play.golang.org/p/fNuI9iVw0S