### PR TITLE
lib/internal: allow auto fallback from v2 API to v1

### DIFF
--- a/lib/internal/backend/repository/repository.go
+++ b/lib/internal/backend/repository/repository.go
@@ -94,7 +94,6 @@ func (rb *RepositoryBackend) GetImageInfo(url string) ([]string, *types.ParsedDo
 	var supportsV2, supportsV1, ok bool
 	var URLSchema string
 
-	//probe v2
 	if supportsV2, ok = rb.hostsV2Support[dockerURL.IndexURL]; !ok {
 		var err error
 		URLSchema, supportsV2, err = rb.supportsRegistry(dockerURL.IndexURL, registryV2)
@@ -111,11 +110,10 @@ func (rb *RepositoryBackend) GetImageInfo(url string) ([]string, *types.ParsedDo
 		if !isErrHTTP404(err) {
 			return layers, dockerURL, err
 		}
-		// fallback on failure
+		// fallback on 404 failure
 		rb.hostsV1fallback = true
 	}
 
-	// probe v1
 	URLSchema, supportsV1, err = rb.supportsRegistry(dockerURL.IndexURL, registryV1)
 	if err != nil {
 		return nil, nil, err

--- a/lib/internal/backend/repository/repository.go
+++ b/lib/internal/backend/repository/repository.go
@@ -39,11 +39,28 @@ const (
 	registryV2
 )
 
+type httpStatusErr struct {
+	StatusCode int
+	URL        *url.URL
+}
+
+func (e httpStatusErr) Error() string {
+	return fmt.Sprintf("Unexpected HTTP code: %d, URL: %s", e.StatusCode, e.URL.String())
+}
+
+func isErrHTTP404(err error) bool {
+	if httperr, ok := err.(*httpStatusErr); ok && httperr.StatusCode == http.StatusNotFound {
+		return true
+	}
+	return false
+}
+
 type RepositoryBackend struct {
 	repoData          *RepoData
 	username          string
 	password          string
 	insecure          common.InsecureConfig
+	hostsV1fallback   bool
 	hostsV2Support    map[string]bool
 	hostsV2AuthTokens map[string]map[string]string
 	schema            string
@@ -58,6 +75,7 @@ func NewRepositoryBackend(username string, password string, insecure common.Inse
 		username:          username,
 		password:          password,
 		insecure:          insecure,
+		hostsV1fallback:   false,
 		hostsV2Support:    make(map[string]bool),
 		hostsV2AuthTokens: make(map[string]map[string]string),
 		imageManifests:    make(map[types.ParsedDockerURL]v2Manifest),
@@ -73,8 +91,10 @@ func (rb *RepositoryBackend) GetImageInfo(url string) ([]string, *types.ParsedDo
 		return nil, nil, err
 	}
 
-	var supportsV2, ok bool
+	var supportsV2, supportsV1, ok bool
 	var URLSchema string
+
+	//probe v2
 	if supportsV2, ok = rb.hostsV2Support[dockerURL.IndexURL]; !ok {
 		var err error
 		URLSchema, supportsV2, err = rb.supportsRegistry(dockerURL.IndexURL, registryV2)
@@ -85,26 +105,37 @@ func (rb *RepositoryBackend) GetImageInfo(url string) ([]string, *types.ParsedDo
 		rb.hostsV2Support[dockerURL.IndexURL] = supportsV2
 	}
 
+	// try v2
 	if supportsV2 {
-		return rb.getImageInfoV2(dockerURL)
-	} else {
-		URLSchema, supportsV1, err := rb.supportsRegistry(dockerURL.IndexURL, registryV1)
-		if err != nil {
-			return nil, nil, err
+		layers, dockerURL, err := rb.getImageInfoV2(dockerURL)
+		if !isErrHTTP404(err) {
+			return layers, dockerURL, err
 		}
-		if !supportsV1 {
-			return nil, nil, fmt.Errorf("registry doesn't support API v2 nor v1")
-		}
-		rb.schema = URLSchema + "://"
-		return rb.getImageInfoV1(dockerURL)
+		// fallback on failure
+		rb.hostsV1fallback = true
 	}
+
+	// probe v1
+	URLSchema, supportsV1, err = rb.supportsRegistry(dockerURL.IndexURL, registryV1)
+	if err != nil {
+		return nil, nil, err
+	}
+	if !supportsV1 && rb.hostsV1fallback {
+		return nil, nil, fmt.Errorf("attempted fallback to API v1 but not supported")
+	}
+	if !supportsV1 && !supportsV2 {
+		return nil, nil, fmt.Errorf("registry doesn't support API v2 nor v1")
+	}
+	rb.schema = URLSchema + "://"
+	// try v1, hard fail on failure
+	return rb.getImageInfoV1(dockerURL)
 }
 
 func (rb *RepositoryBackend) BuildACI(layerIDs []string, dockerURL *types.ParsedDockerURL, outputDir string, tmpBaseDir string, compression common.Compression) ([]string, []*schema.ImageManifest, error) {
-	if rb.hostsV2Support[dockerURL.IndexURL] {
-		return rb.buildACIV2(layerIDs, dockerURL, outputDir, tmpBaseDir, compression)
-	} else {
+	if rb.hostsV1fallback || !rb.hostsV2Support[dockerURL.IndexURL] {
 		return rb.buildACIV1(layerIDs, dockerURL, outputDir, tmpBaseDir, compression)
+	} else {
+		return rb.buildACIV2(layerIDs, dockerURL, outputDir, tmpBaseDir, compression)
 	}
 }
 

--- a/lib/internal/backend/repository/repository1.go
+++ b/lib/internal/backend/repository/repository1.go
@@ -158,7 +158,7 @@ func (rb *RepositoryBackend) getRepoDataV1(indexURL string, remote string) (*Rep
 	defer res.Body.Close()
 
 	if res.StatusCode != 200 {
-		return nil, fmt.Errorf("HTTP code: %d, URL: %s", res.StatusCode, req.URL)
+		return nil, &httpStatusErr{res.StatusCode, req.URL}
 	}
 
 	var tokens []string
@@ -206,7 +206,7 @@ func (rb *RepositoryBackend) getImageIDFromTagV1(registry string, appName string
 	defer res.Body.Close()
 
 	if res.StatusCode != 200 {
-		return "", fmt.Errorf("HTTP code: %d. URL: %s", res.StatusCode, req.URL)
+		return "", &httpStatusErr{res.StatusCode, req.URL}
 	}
 
 	j, err := ioutil.ReadAll(res.Body)
@@ -245,7 +245,7 @@ func (rb *RepositoryBackend) getAncestryV1(imgID, registry string, repoData *Rep
 	defer res.Body.Close()
 
 	if res.StatusCode != 200 {
-		return nil, fmt.Errorf("HTTP code: %d. URL: %s", res.StatusCode, req.URL)
+		return nil, &httpStatusErr{res.StatusCode, req.URL}
 	}
 
 	var ancestry []string
@@ -277,7 +277,7 @@ func (rb *RepositoryBackend) getJsonV1(imgID, registry string, repoData *RepoDat
 	defer res.Body.Close()
 
 	if res.StatusCode != 200 {
-		return nil, -1, fmt.Errorf("HTTP code: %d, URL: %s", res.StatusCode, req.URL)
+		return nil, -1, &httpStatusErr{res.StatusCode, req.URL}
 	}
 
 	imageSize := int64(-1)
@@ -315,7 +315,7 @@ func (rb *RepositoryBackend) getLayerV1(imgID, registry string, repoData *RepoDa
 
 	if res.StatusCode != 200 {
 		res.Body.Close()
-		return nil, fmt.Errorf("HTTP code: %d. URL: %s", res.StatusCode, req.URL)
+		return nil, &httpStatusErr{res.StatusCode, req.URL}
 	}
 
 	// if we didn't receive the size via X-Docker-Size when we retrieved the

--- a/lib/internal/backend/repository/repository2.go
+++ b/lib/internal/backend/repository/repository2.go
@@ -308,7 +308,7 @@ func (rb *RepositoryBackend) getManifestV2(dockerURL *types.ParsedDockerURL) ([]
 	defer res.Body.Close()
 
 	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("unexpected http code: %d, URL: %s", res.StatusCode, req.URL)
+		return nil, &httpStatusErr{res.StatusCode, req.URL}
 	}
 
 	switch res.Header.Get("content-type") {
@@ -520,7 +520,7 @@ func (rb *RepositoryBackend) getLayerV2(layerID string, dockerURL *types.ParsedD
 	}
 
 	if res.StatusCode != http.StatusOK {
-		return nil, nil, fmt.Errorf("HTTP code: %d. URL: %s", res.StatusCode, req.URL)
+		return nil, nil, &httpStatusErr{res.StatusCode, req.URL}
 	}
 
 	var in io.Reader
@@ -638,7 +638,7 @@ func (rb *RepositoryBackend) makeRequest(req *http.Request, repo string, acceptH
 	case http.StatusOK:
 		break
 	default:
-		return nil, fmt.Errorf("unexpected http code: %d, URL: %s", res.StatusCode, authReq.URL)
+		return nil, &httpStatusErr{res.StatusCode, authReq.URL}
 	}
 
 	tokenBlob, err := ioutil.ReadAll(res.Body)


### PR DESCRIPTION
fixes #221
docker2aci would only attempt the v2 api if a registry supported it.
this check for a 404 error from the v2 api and if so attempts to
fallback to v1.

Workflow:
probe v2, try v2, downgrade-on-failure, probe v1, try v1,
hardfail-on-failure
