### PR TITLE
Map Docker labels to appc UserLabels

### DIFF
--- a/glide.lock
+++ b/glide.lock
@@ -1,8 +1,8 @@
-hash: 5f32573a0491c3c15d8e6654967c0a9b6798ed25cb9f1ae617f916be1730fb5c
-updated: 2016-10-21T13:40:38.649778864Z
+hash: 1792eab6cf0ce9dc090038e49a5e80de41e5cbb38e06852c41915d1758f27239
+updated: 2016-11-04T06:43:11.742331752-07:00
 imports:
 - name: github.com/appc/spec
-  version: f329150233aa3ac6c83ab5ba02a2b5a8bd03d365
+  version: 2a251f75b2520d7a1c6c10562a1ea4e303af3e67
   subpackages:
   - aci
   - pkg/acirenderer

--- a/glide.yaml
+++ b/glide.yaml
@@ -1,7 +1,7 @@
 package: github.com/appc/docker2aci
 import:
 - package: github.com/appc/spec
-  version: 0.8.7
+  version: 0.8.8
   subpackages:
   - aci
   - pkg/acirenderer

--- a/lib/internal/internal.go
+++ b/lib/internal/internal.go
@@ -233,44 +233,42 @@ func GenerateManifest(layerData types.DockerImageData, dockerURL *common.ParsedD
 
 	if dockerConfig != nil {
 		exec := getExecCommand(dockerConfig.Entrypoint, dockerConfig.Cmd)
-		if exec != nil {
-			user, group := parseDockerUser(dockerConfig.User)
-			var env appctypes.Environment
-			for _, v := range dockerConfig.Env {
-				parts := strings.SplitN(v, "=", 2)
-				env.Set(parts[0], parts[1])
-			}
-			app := &appctypes.App{
-				Exec:             exec,
-				User:             user,
-				Group:            group,
-				Environment:      env,
-				WorkingDirectory: dockerConfig.WorkingDir,
-			}
-
-			app.MountPoints, err = convertVolumesToMPs(dockerConfig.Volumes)
-			if err != nil {
-				return nil, err
-			}
-
-			app.Ports, err = convertPorts(dockerConfig.ExposedPorts, dockerConfig.PortSpecs, debug)
-			if err != nil {
-				return nil, err
-			}
-
-			ep, cmd, err := generateEPCmdAnnotation(dockerConfig.Entrypoint, dockerConfig.Cmd)
-			if err != nil {
-				return nil, err
-			}
-			if len(ep) > 0 {
-				addAnno(common.AppcDockerEntrypoint, ep)
-			}
-			if len(cmd) > 0 {
-				addAnno(common.AppcDockerCmd, cmd)
-			}
-
-			genManifest.App = app
+		user, group := parseDockerUser(dockerConfig.User)
+		var env appctypes.Environment
+		for _, v := range dockerConfig.Env {
+			parts := strings.SplitN(v, "=", 2)
+			env.Set(parts[0], parts[1])
 		}
+		app := &appctypes.App{
+			Exec:             exec,
+			User:             user,
+			Group:            group,
+			Environment:      env,
+			WorkingDirectory: dockerConfig.WorkingDir,
+		}
+
+		app.MountPoints, err = convertVolumesToMPs(dockerConfig.Volumes)
+		if err != nil {
+			return nil, err
+		}
+
+		app.Ports, err = convertPorts(dockerConfig.ExposedPorts, dockerConfig.PortSpecs, debug)
+		if err != nil {
+			return nil, err
+		}
+
+		ep, cmd, err := generateEPCmdAnnotation(dockerConfig.Entrypoint, dockerConfig.Cmd)
+		if err != nil {
+			return nil, err
+		}
+		if len(ep) > 0 {
+			addAnno(common.AppcDockerEntrypoint, ep)
+		}
+		if len(cmd) > 0 {
+			addAnno(common.AppcDockerCmd, cmd)
+		}
+
+		genManifest.App = app
 	}
 
 	if layerData.Parent != "" {

--- a/lib/internal/internal.go
+++ b/lib/internal/internal.go
@@ -247,6 +247,8 @@ func GenerateManifest(layerData types.DockerImageData, dockerURL *common.ParsedD
 			WorkingDirectory: dockerConfig.WorkingDir,
 		}
 
+		app.UserLabels = dockerConfig.Labels
+
 		app.MountPoints, err = convertVolumesToMPs(dockerConfig.Volumes)
 		if err != nil {
 			return nil, err

--- a/lib/internal/types/docker_types.go
+++ b/lib/internal/types/docker_types.go
@@ -62,6 +62,7 @@ type DockerImageConfig struct {
 	NetworkDisabled bool
 	MacAddress      string
 	OnBuild         []string
+	Labels          map[string]string
 }
 
 // DockerAuthConfigOld represents the deprecated ~/.dockercfg auth

--- a/vendor/github.com/appc/spec/schema/pod.go
+++ b/vendor/github.com/appc/spec/schema/pod.go
@@ -28,13 +28,15 @@ import (
 const PodManifestKind = types.ACKind("PodManifest")
 
 type PodManifest struct {
-	ACVersion   types.SemVer        `json:"acVersion"`
-	ACKind      types.ACKind        `json:"acKind"`
-	Apps        AppList             `json:"apps"`
-	Volumes     []types.Volume      `json:"volumes"`
-	Isolators   []types.Isolator    `json:"isolators"`
-	Annotations types.Annotations   `json:"annotations"`
-	Ports       []types.ExposedPort `json:"ports"`
+	ACVersion       types.SemVer          `json:"acVersion"`
+	ACKind          types.ACKind          `json:"acKind"`
+	Apps            AppList               `json:"apps"`
+	Volumes         []types.Volume        `json:"volumes"`
+	Isolators       []types.Isolator      `json:"isolators"`
+	Annotations     types.Annotations     `json:"annotations"`
+	Ports           []types.ExposedPort   `json:"ports"`
+	UserAnnotations types.UserAnnotations `json:"userAnnotations,omitempty"`
+	UserLabels      types.UserLabels      `json:"userLabels,omitempty"`
 }
 
 // podManifest is a model to facilitate extra validation during the
@@ -135,9 +137,12 @@ func (al AppList) Get(name types.ACName) *RuntimeApp {
 
 // Mount describes the mapping between a volume and the path it is mounted
 // inside of an app's filesystem.
+// The AppVolume is optional. If missing, the pod-level Volume of the
+// same name shall be used.
 type Mount struct {
-	Volume types.ACName `json:"volume"`
-	Path   string       `json:"path"`
+	Volume    types.ACName  `json:"volume"`
+	Path      string        `json:"path"`
+	AppVolume *types.Volume `json:"appVolume,omitempty"`
 }
 
 func (r Mount) assertValid() error {

--- a/vendor/github.com/appc/spec/schema/types/app.go
+++ b/vendor/github.com/appc/spec/schema/types/app.go
@@ -22,16 +22,18 @@ import (
 )
 
 type App struct {
-	Exec              Exec           `json:"exec"`
-	EventHandlers     []EventHandler `json:"eventHandlers,omitempty"`
-	User              string         `json:"user"`
-	Group             string         `json:"group"`
-	SupplementaryGIDs []int          `json:"supplementaryGIDs,omitempty"`
-	WorkingDirectory  string         `json:"workingDirectory,omitempty"`
-	Environment       Environment    `json:"environment,omitempty"`
-	MountPoints       []MountPoint   `json:"mountPoints,omitempty"`
-	Ports             []Port         `json:"ports,omitempty"`
-	Isolators         Isolators      `json:"isolators,omitempty"`
+	Exec              Exec            `json:"exec"`
+	EventHandlers     []EventHandler  `json:"eventHandlers,omitempty"`
+	User              string          `json:"user"`
+	Group             string          `json:"group"`
+	SupplementaryGIDs []int           `json:"supplementaryGIDs,omitempty"`
+	WorkingDirectory  string          `json:"workingDirectory,omitempty"`
+	Environment       Environment     `json:"environment,omitempty"`
+	MountPoints       []MountPoint    `json:"mountPoints,omitempty"`
+	Ports             []Port          `json:"ports,omitempty"`
+	Isolators         Isolators       `json:"isolators,omitempty"`
+	UserAnnotations   UserAnnotations `json:"userAnnotations,omitempty"`
+	UserLabels        UserLabels      `json:"userLabels,omitempty"`
 }
 
 // app is a model to facilitate extra validation during the

--- a/vendor/github.com/appc/spec/schema/types/isolator_linux_specific.go
+++ b/vendor/github.com/appc/spec/schema/types/isolator_linux_specific.go
@@ -17,6 +17,7 @@ package types
 import (
 	"encoding/json"
 	"errors"
+	"fmt"
 	"unicode"
 )
 
@@ -26,6 +27,8 @@ const (
 	LinuxNoNewPrivilegesName       = "os/linux/no-new-privileges"
 	LinuxSeccompRemoveSetName      = "os/linux/seccomp-remove-set"
 	LinuxSeccompRetainSetName      = "os/linux/seccomp-retain-set"
+	LinuxOOMScoreAdjName           = "os/linux/oom-score-adj"
+	LinuxCPUSharesName             = "os/linux/cpu-shares"
 )
 
 var LinuxIsolatorNames = make(map[ACIdentifier]struct{})
@@ -35,6 +38,8 @@ func init() {
 		LinuxCapabilitiesRevokeSetName: func() IsolatorValue { return &LinuxCapabilitiesRevokeSet{} },
 		LinuxCapabilitiesRetainSetName: func() IsolatorValue { return &LinuxCapabilitiesRetainSet{} },
 		LinuxNoNewPrivilegesName:       func() IsolatorValue { v := LinuxNoNewPrivileges(false); return &v },
+		LinuxOOMScoreAdjName:           func() IsolatorValue { v := LinuxOOMScoreAdj(0); return &v },
+		LinuxCPUSharesName:             func() IsolatorValue { v := LinuxCPUShares(1024); return &v },
 		LinuxSeccompRemoveSetName:      func() IsolatorValue { return &LinuxSeccompRemoveSet{} },
 		LinuxSeccompRetainSetName:      func() IsolatorValue { return &LinuxSeccompRetainSet{} },
 	} {
@@ -320,4 +325,108 @@ func (l LinuxSeccompRemoveSet) AsIsolator() (*Isolator, error) {
 		ValueRaw: &rm,
 		value:    &l,
 	}, nil
+}
+
+// LinuxCPUShares assigns the CPU time share weight to the processes executed.
+// See https://www.freedesktop.org/software/systemd/man/systemd.resource-control.html#CPUShares=weight,
+// https://www.kernel.org/doc/Documentation/scheduler/sched-design-CFS.txt
+type LinuxCPUShares int
+
+func NewLinuxCPUShares(val int) (*LinuxCPUShares, error) {
+	l := LinuxCPUShares(val)
+	if err := l.AssertValid(); err != nil {
+		return nil, err
+	}
+
+	return &l, nil
+}
+
+func (l LinuxCPUShares) AssertValid() error {
+	if l < 2 || l > 262144 {
+		return fmt.Errorf("%s must be between 2 and 262144, got %d", LinuxCPUSharesName, l)
+	}
+	return nil
+}
+
+func (l LinuxCPUShares) multipleAllowed() bool {
+	return false
+}
+
+func (l LinuxCPUShares) Conflicts() []ACIdentifier {
+	return nil
+}
+
+func (l *LinuxCPUShares) UnmarshalJSON(b []byte) error {
+	var v int
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+
+	*l = LinuxCPUShares(v)
+	return nil
+}
+
+func (l LinuxCPUShares) AsIsolator() Isolator {
+	b, err := json.Marshal(l)
+	if err != nil {
+		panic(err)
+	}
+	rm := json.RawMessage(b)
+	return Isolator{
+		Name:     LinuxCPUSharesName,
+		ValueRaw: &rm,
+		value:    &l,
+	}
+}
+
+// LinuxOOMScoreAdj is equivalent to /proc/[pid]/oom_score_adj
+type LinuxOOMScoreAdj int // -1000 to 1000
+
+func NewLinuxOOMScoreAdj(val int) (*LinuxOOMScoreAdj, error) {
+	l := LinuxOOMScoreAdj(val)
+	if err := l.AssertValid(); err != nil {
+		return nil, err
+	}
+
+	return &l, nil
+}
+
+func (l LinuxOOMScoreAdj) AssertValid() error {
+	if l < -1000 || l > 1000 {
+		return fmt.Errorf("%s must be between -1000 and 1000, got %d", LinuxOOMScoreAdjName, l)
+	}
+	return nil
+}
+
+func (l LinuxOOMScoreAdj) multipleAllowed() bool {
+	return false
+}
+
+func (l LinuxOOMScoreAdj) Conflicts() []ACIdentifier {
+	return nil
+}
+
+func (l *LinuxOOMScoreAdj) UnmarshalJSON(b []byte) error {
+	var v int
+	err := json.Unmarshal(b, &v)
+	if err != nil {
+		return err
+	}
+
+	*l = LinuxOOMScoreAdj(v)
+	return nil
+}
+
+func (l LinuxOOMScoreAdj) AsIsolator() Isolator {
+	b, err := json.Marshal(l)
+	if err != nil {
+		panic(err)
+	}
+	rm := json.RawMessage(b)
+	return Isolator{
+		Name:     LinuxOOMScoreAdjName,
+		ValueRaw: &rm,
+		value:    &l,
+	}
 }

--- a/vendor/github.com/appc/spec/schema/types/mountpoint.go
+++ b/vendor/github.com/appc/spec/schema/types/mountpoint.go
@@ -23,6 +23,7 @@ import (
 	"github.com/appc/spec/schema/common"
 )
 
+// MountPoint is the application-side manifestation of a Volume.
 type MountPoint struct {
 	Name     ACName `json:"name"`
 	Path     string `json:"path"`

--- a/vendor/github.com/appc/spec/schema/types/port.go
+++ b/vendor/github.com/appc/spec/schema/types/port.go
@@ -18,12 +18,15 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
+	"net"
 	"net/url"
 	"strconv"
 
 	"github.com/appc/spec/schema/common"
 )
 
+// Port represents a port as offered by an application *inside*
+// the pod.
 type Port struct {
 	Name            ACName `json:"name"`
 	Protocol        string `json:"protocol"`
@@ -32,9 +35,14 @@ type Port struct {
 	SocketActivated bool   `json:"socketActivated"`
 }
 
+// ExposedPort represents a port listening on the host side.
+// The PodPort is optional -- if missing, then try and find the pod-side
+// information by matching names
 type ExposedPort struct {
 	Name     ACName `json:"name"`
 	HostPort uint   `json:"hostPort"`
+	HostIP   net.IP `json:"hostIP,omitempty"`  // optional
+	PodPort  *Port  `json:"podPort,omitempty"` // optional. If missing, try and find a corresponding App's port
 }
 
 type port Port

--- a/vendor/github.com/appc/spec/schema/types/user_annotations.go
+++ b/vendor/github.com/appc/spec/schema/types/user_annotations.go
@@ -1,0 +1,18 @@
+// Copyright 2016 The appc Authors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package types
+
+// UserAnnotations are arbitrary key-value pairs, to be supplied and interpreted by the user
+type UserAnnotations map[string]string

--- a/vendor/github.com/appc/spec/schema/types/user_labels.go
+++ b/vendor/github.com/appc/spec/schema/types/user_labels.go
@@ -12,28 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-package schema
+package types
 
-import (
-	"github.com/appc/spec/schema/types"
-)
-
-const (
-	// version represents the canonical version of the appc spec and tooling.
-	// For now, the schema and tooling is coupled with the spec itself, so
-	// this must be kept in sync with the VERSION file in the root of the repo.
-	version string = "0.8.8"
-)
-
-var (
-	// AppContainerVersion is the SemVer representation of version
-	AppContainerVersion types.SemVer
-)
-
-func init() {
-	v, err := types.NewSemVer(version)
-	if err != nil {
-		panic(err)
-	}
-	AppContainerVersion = *v
-}
+// UserLabels are arbitrary key-value pairs, to be supplied and interpreted by the user
+type UserLabels map[string]string

--- a/vendor/github.com/appc/spec/schema/types/volume.go
+++ b/vendor/github.com/appc/spec/schema/types/volume.go
@@ -156,8 +156,6 @@ func (v Volume) String() string {
 // Example volume parameters:
 // 	database,kind=host,source=/tmp,readOnly=true,recursive=true
 func VolumeFromString(vp string) (*Volume, error) {
-	var vol Volume
-
 	vp = "name=" + vp
 	vpQuery, err := common.MakeQueryString(vp)
 	if err != nil {
@@ -168,7 +166,12 @@ func VolumeFromString(vp string) (*Volume, error) {
 	if err != nil {
 		return nil, err
 	}
-	for key, val := range v {
+	return VolumeFromParams(v)
+}
+
+func VolumeFromParams(params map[string][]string) (*Volume, error) {
+	var vol Volume
+	for key, val := range params {
 		val := val
 		if len(val) > 1 {
 			return nil, fmt.Errorf("label %s with multiple values %q", key, val)
@@ -218,8 +221,7 @@ func VolumeFromString(vp string) (*Volume, error) {
 
 	maybeSetDefaults(&vol)
 
-	err = vol.assertValid()
-	if err != nil {
+	if err := vol.assertValid(); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
this is a second version of https://github.com/appc/docker2aci/pull/209!

I started out by just converting Docker labels to UserLabels. But then I realized there was a problem! Sometimes, when the Docker image doesn't have a `Cmd` in it, the labels wouldn't get converted.

So I also changed it to not require an image to have a Docker command to convert the other Docker metadata on the image. I can't see why this wouldn't work, but probably there's some reason I don't know yet that this `exec != nil` check was there in the first place.

(also I might have gotten the vendoring wrong -- I haven't used glide before)