### PR TITLE
fetch: annotate originally requested name

### DIFF
--- a/lib/common/common.go
+++ b/lib/common/common.go
@@ -35,6 +35,12 @@ var (
 )
 
 const (
+	// AppcDockerOriginalName is the unmodified name this image was originally
+	// referenced by for fetching, e.g. something like "nginx:tag" or
+	// "quay.io/user/image:latest" This is identical in most cases to
+	// 'registryurl/repository:tag' but may differ for the default Dockerhub
+	// registry or if the tag was inferred as latest.
+	AppcDockerOriginalName  = "appc.io/docker/originalname"
 	AppcDockerRegistryURL   = "appc.io/docker/registryurl"
 	AppcDockerRepository    = "appc.io/docker/repository"
 	AppcDockerTag           = "appc.io/docker/tag"
@@ -48,10 +54,11 @@ const defaultTag = "latest"
 
 // ParsedDockerURL represents a parsed Docker URL.
 type ParsedDockerURL struct {
-	IndexURL  string
-	ImageName string
-	Tag       string
-	Digest    string
+	OriginalName string
+	IndexURL     string
+	ImageName    string
+	Tag          string
+	Digest       string
 }
 
 type ErrSeveralImages struct {
@@ -90,10 +97,11 @@ func ParseDockerURL(arg string) (*ParsedDockerURL, error) {
 	indexURL, remoteName := docker.SplitReposName(r.Name())
 
 	return &ParsedDockerURL{
-		IndexURL:  indexURL,
-		ImageName: remoteName,
-		Tag:       tag,
-		Digest:    digest,
+		OriginalName: arg,
+		IndexURL:     indexURL,
+		ImageName:    remoteName,
+		Tag:          tag,
+		Digest:       digest,
 	}, nil
 }
 

--- a/lib/internal/backend/file/file.go
+++ b/lib/internal/backend/file/file.go
@@ -260,9 +260,10 @@ func getImageID(file *os.File, dockerURL *common.ParsedDockerURL, name string, d
 
 			if dockerURL == nil {
 				dockerURL = &common.ParsedDockerURL{
-					IndexURL:  "",
-					Tag:       tag,
-					ImageName: appName,
+					OriginalName: "",
+					IndexURL:     "",
+					Tag:          tag,
+					ImageName:    appName,
 				}
 			}
 

--- a/lib/internal/internal.go
+++ b/lib/internal/internal.go
@@ -226,6 +226,7 @@ func GenerateManifest(layerData types.DockerImageData, dockerURL *common.ParsedD
 		addAnno("created", layerData.Created.Format(time.RFC3339))
 	}
 	addAnno("docker-comment", layerData.Comment)
+	addAnno(common.AppcDockerOriginalName, dockerURL.OriginalName)
 	addAnno(common.AppcDockerRegistryURL, dockerURL.IndexURL)
 	addAnno(common.AppcDockerRepository, dockerURL.ImageName)
 	addAnno(common.AppcDockerImageID, layerData.ID)
@@ -356,6 +357,7 @@ func GenerateManifestV22(name string, dockerURL *common.ParsedDockerURL, config 
 	addAnno("author", config.Author)
 	addAnno("created", config.Created)
 
+	addAnno(common.AppcDockerOriginalName, dockerURL.OriginalName)
 	addAnno(common.AppcDockerRegistryURL, dockerURL.IndexURL)
 	addAnno(common.AppcDockerRepository, dockerURL.ImageName)
 	addAnno(common.AppcDockerImageID, imageDigest)


### PR DESCRIPTION
Currently, there's no lossless way to actually recover this information.

e.g. if the user fetches: nginx:latest vs library/nginx:latest, the two
outputs are identical.

This provides a way to recover that input.

cc @lucab 