### PR TITLE
build: use git describe fallback

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -7,7 +7,7 @@ DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
 ORG_PATH="github.com/appc"
 REPO_PATH="${ORG_PATH}/docker2aci"
-VERSION=$(git describe --dirty)
+VERSION=$(git describe --dirty --always)
 GLDFLAGS="-X ${REPO_PATH}/lib.Version=${VERSION}"
 
 if [ ! -h ${DIR}/gopath/src/${REPO_PATH} ]; then


### PR DESCRIPTION
Pass `--always` to `git describe`, falling back to commit revision
in case tags were not fetched.
This workarounds some non-deterministic race/failure on semaphore:
```
fatal: No names found, cannot describe anything.
```