### PR TITLE
scripts: update glide-update vendor script

### DIFF
--- a/scripts/glide-update
+++ b/scripts/glide-update
@@ -16,5 +16,5 @@ if [ ! $(command -v glide-vc)  ]; then
   exit 255
 fi
 
-glide update --strip-vcs --strip-vendor --update-vendored --delete
+glide update --strip-vendor
 glide-vc --only-code --no-tests


### PR DESCRIPTION
The current glide update flags are deprecated, and the current settings
are default behavior in glide.

This fixes it.