### PR TITLE
Image from file improvements; guesses at "originalname" and fixes for "--image"

### DIFF
--- a/lib/internal/backend/file/file.go
+++ b/lib/internal/backend/file/file.go
@@ -54,10 +54,15 @@ func NewFileBackend(file *os.File, debug, info log.Logger) *FileBackend {
 }
 
 func (lb *FileBackend) GetImageInfo(dockerURL string) ([]string, *common.ParsedDockerURL, error) {
-	parsedDockerURL, err := common.ParseDockerURL(dockerURL)
-	if err != nil {
-		// a missing Docker URL could mean that the file only contains one
-		// image, so we ignore the error here, we'll handle it in getImageID
+	// a missing Docker URL could mean that the file only contains one
+	// image so it's okay for dockerURL to be blank
+	var parsedDockerURL *common.ParsedDockerURL
+	if dockerURL != "" {
+		var err error
+		parsedDockerURL, err = common.ParseDockerURL(dockerURL)
+		if err != nil {
+			return nil, nil, fmt.Errorf("image provided couldnot be parsed: %v", err)
+		}
 	}
 
 	var ancestry []string


### PR DESCRIPTION
The use case is rktlet wanting the `originalname` value when using `docker2aci` + `rkt fetch`.

Originally I figured I could use `--image=...` to have `originalname` end up there rather than guessing at it, but `--image` was broken for any images that need special handling (namely all library/ dockerhub images), and after thinking about it a bit more I think taking a guess at the originalname is okay here.

I left a fairly detailed commit comment for the most complicated of the changes, and the commits are broken up into nice bite-sized diffs.

