### PR TITLE
Move OCI support behind experimental flag

### DIFF
--- a/lib/docker2aci.go
+++ b/lib/docker2aci.go
@@ -65,9 +65,10 @@ func (c *CommonConfig) initLogger() {
 // converting Docker images.
 type RemoteConfig struct {
 	CommonConfig
-	Username string                // username to use if the image to convert needs authentication
-	Password string                // password to use if the image to convert needs authentication
-	Insecure common.InsecureConfig // Insecure options
+	Username   string                // username to use if the image to convert needs authentication
+	Password   string                // password to use if the image to convert needs authentication
+	Insecure   common.InsecureConfig // Insecure options
+	OCISupport bool                  // Experimental flag to enable OCI support
 }
 
 // FileConfig represents the saved file specific configuration for converting
@@ -94,6 +95,7 @@ func ConvertRemoteRepo(dockerURL string, config RemoteConfig) ([]string, error) 
 			config.Password,
 			config.Insecure,
 			config.Debug,
+			config.OCISupport,
 		),
 		dockerURL: dockerURL,
 		config:    config.CommonConfig,

--- a/lib/internal/backend/repository/repository.go
+++ b/lib/internal/backend/repository/repository.go
@@ -67,11 +67,12 @@ type RepositoryBackend struct {
 	imageV2Manifests  map[common.ParsedDockerURL]*typesV2.ImageManifest
 	imageConfigs      map[common.ParsedDockerURL]*typesV2.ImageConfig
 	layersIndex       map[string]int
+	ociSupport        bool
 
 	debug log.Logger
 }
 
-func NewRepositoryBackend(username string, password string, insecure common.InsecureConfig, debug log.Logger) *RepositoryBackend {
+func NewRepositoryBackend(username string, password string, insecure common.InsecureConfig, debug log.Logger, ociSupport bool) *RepositoryBackend {
 	return &RepositoryBackend{
 		username:          username,
 		password:          password,
@@ -83,6 +84,7 @@ func NewRepositoryBackend(username string, password string, insecure common.Inse
 		imageV2Manifests:  make(map[common.ParsedDockerURL]*typesV2.ImageManifest),
 		imageConfigs:      make(map[common.ParsedDockerURL]*typesV2.ImageConfig),
 		layersIndex:       make(map[string]int),
+		ociSupport:        ociSupport,
 		debug:             debug,
 	}
 }

--- a/lib/internal/backend/repository/repository2.go
+++ b/lib/internal/backend/repository/repository2.go
@@ -295,9 +295,11 @@ func (rb *RepositoryBackend) getManifestV2(dockerURL *common.ParsedDockerURL) ([
 	rb.setBasicAuth(req)
 
 	accepting := []string{
-		typesV2.MediaTypeOCIManifest,
 		typesV2.MediaTypeDockerV22Manifest,
 		typesV2.MediaTypeDockerV21Manifest,
+	}
+	if rb.ociSupport {
+		accepting = append(accepting, typesV2.MediaTypeOCIManifest)
 	}
 
 	res, err := rb.makeRequest(req, dockerURL.ImageName, accepting)
@@ -400,9 +402,9 @@ func (rb *RepositoryBackend) getConfigV22(dockerURL *common.ParsedDockerURL, con
 
 	rb.setBasicAuth(req)
 
-	accepting := []string{
-		typesV2.MediaTypeOCIConfig,
-		typesV2.MediaTypeDockerV22Config,
+	accepting := []string{typesV2.MediaTypeDockerV22Config}
+	if rb.ociSupport {
+		accepting = append(accepting, typesV2.MediaTypeOCIConfig)
 	}
 
 	res, err := rb.makeRequest(req, dockerURL.ImageName, accepting)
@@ -486,9 +488,9 @@ func (rb *RepositoryBackend) getLayerV2(layerID string, dockerURL *common.Parsed
 
 	rb.setBasicAuth(req)
 
-	accepting := []string{
-		typesV2.MediaTypeDockerV22RootFS,
-		typesV2.MediaTypeOCILayer,
+	accepting := []string{typesV2.MediaTypeDockerV22RootFS}
+	if rb.ociSupport {
+		accepting = append(accepting, typesV2.MediaTypeOCILayer)
 	}
 
 	res, err = rb.makeRequest(req, dockerURL.ImageName, accepting)

--- a/main.go
+++ b/main.go
@@ -37,6 +37,7 @@ var (
 	flagInsecureAllowHTTP  bool
 	flagCompression        string
 	flagVersion            bool
+	flagOCISupport         bool
 )
 
 func init() {
@@ -47,6 +48,7 @@ func init() {
 	flag.BoolVar(&flagInsecureAllowHTTP, "insecure-allow-http", false, "Uses unencrypted connections when fetching images")
 	flag.StringVar(&flagCompression, "compression", "gzip", "Type of compression to use; allowed values: gzip, none")
 	flag.BoolVar(&flagVersion, "version", false, "Print version")
+	flag.BoolVar(&flagOCISupport, "experimental-oci", false, "Enable experimental OCI support")
 }
 
 func printVersion() {
@@ -111,6 +113,7 @@ func runDocker2ACI(arg string) error {
 				SkipVerify: flagInsecureSkipVerify,
 				AllowHTTP:  flagInsecureAllowHTTP,
 			},
+			OCISupport: flagOCISupport,
 		}
 
 		aciLayerPaths, err = docker2aci.ConvertRemoteRepo(dockerURL, remoteConfig)


### PR DESCRIPTION
This commit adds a boolean flag to both the library and cli interfaces
to enable OCI support, that defaults to off. OCI support is
enabled/disabled by altering the Accept HTTP headers on requests
(specifically the OCI media types are added/omitted appropriately).

This is necessary for https://github.com/coreos/rkt/issues/3134 to be implemented in rkt, and is related to https://github.com/appc/docker2aci/issues/216.