### PR TITLE
Annotate manifest hash

### DIFF
--- a/lib/common/common.go
+++ b/lib/common/common.go
@@ -48,6 +48,7 @@ const (
 	AppcDockerParentImageID = "appc.io/docker/parentimageid"
 	AppcDockerEntrypoint    = "appc.io/docker/entrypoint"
 	AppcDockerCmd           = "appc.io/docker/cmd"
+	AppcDockerManifestHash  = "appc.io/docker/manifesthash"
 )
 
 const defaultTag = "latest"

--- a/lib/docker2aci.go
+++ b/lib/docker2aci.go
@@ -42,10 +42,11 @@ import (
 // CommonConfig represents the shared configuration options for converting
 // Docker images.
 type CommonConfig struct {
-	Squash      bool               // squash the layers in one file
-	OutputDir   string             // where to put the resulting ACI
-	TmpDir      string             // directory to use for temporary files
-	Compression common.Compression // which compression to use for the resulting file(s)
+	Squash                bool               // squash the layers in one file
+	OutputDir             string             // where to put the resulting ACI
+	TmpDir                string             // directory to use for temporary files
+	Compression           common.Compression // which compression to use for the resulting file(s)
+	CurrentManifestHashes []string           // any manifest hashes the caller already has
 
 	Info  log.Logger
 	Debug log.Logger
@@ -144,6 +145,11 @@ func (c *converter) convert() ([]string, error) {
 	ancestry, manhash, parsedDockerURL, err := c.backend.GetImageInfo(c.dockerURL)
 	if err != nil {
 		return nil, err
+	}
+	for _, h := range c.config.CurrentManifestHashes {
+		if manhash == h {
+			return nil, nil
+		}
 	}
 
 	layersOutputDir := c.config.OutputDir

--- a/lib/docker2aci.go
+++ b/lib/docker2aci.go
@@ -141,7 +141,7 @@ type converter struct {
 
 func (c *converter) convert() ([]string, error) {
 	c.config.Debug.Println("Getting image info...")
-	ancestry, parsedDockerURL, err := c.backend.GetImageInfo(c.dockerURL)
+	ancestry, manhash, parsedDockerURL, err := c.backend.GetImageInfo(c.dockerURL)
 	if err != nil {
 		return nil, err
 	}
@@ -163,7 +163,7 @@ func (c *converter) convert() ([]string, error) {
 		layerCompression = common.NoCompression
 	}
 
-	aciLayerPaths, aciManifests, err := c.backend.BuildACI(ancestry, parsedDockerURL, layersOutputDir, c.config.TmpDir, layerCompression)
+	aciLayerPaths, aciManifests, err := c.backend.BuildACI(ancestry, manhash, parsedDockerURL, layersOutputDir, c.config.TmpDir, layerCompression)
 	if err != nil {
 		return nil, err
 	}

--- a/lib/internal/backend/repository/repository.go
+++ b/lib/internal/backend/repository/repository.go
@@ -87,10 +87,16 @@ func NewRepositoryBackend(username string, password string, insecure common.Inse
 	}
 }
 
-func (rb *RepositoryBackend) GetImageInfo(url string) ([]string, *common.ParsedDockerURL, error) {
+// GetImageInfo, given the url for a docker image, will return the
+// following:
+// - []string: an ordered list of all layer hashes
+// - string: a unique identifier for this image, like a hash of the manifest
+// - *common.ParsedDockerURL: a parsed docker URL
+// - error: an error if one occurred
+func (rb *RepositoryBackend) GetImageInfo(url string) ([]string, string, *common.ParsedDockerURL, error) {
 	dockerURL, err := common.ParseDockerURL(url)
 	if err != nil {
-		return nil, nil, err
+		return nil, "", nil, err
 	}
 
 	var supportsV2, supportsV1, ok bool
@@ -100,7 +106,7 @@ func (rb *RepositoryBackend) GetImageInfo(url string) ([]string, *common.ParsedD
 		var err error
 		URLSchema, supportsV2, err = rb.supportsRegistry(dockerURL.IndexURL, registryV2)
 		if err != nil {
-			return nil, nil, err
+			return nil, "", nil, err
 		}
 		rb.schema = URLSchema + "://"
 		rb.hostsV2Support[dockerURL.IndexURL] = supportsV2
@@ -108,9 +114,9 @@ func (rb *RepositoryBackend) GetImageInfo(url string) ([]string, *common.ParsedD
 
 	// try v2
 	if supportsV2 {
-		layers, dockerURL, err := rb.getImageInfoV2(dockerURL)
+		layers, manhash, dockerURL, err := rb.getImageInfoV2(dockerURL)
 		if !isErrHTTP404(err) {
-			return layers, dockerURL, err
+			return layers, manhash, dockerURL, err
 		}
 		// fallback on 404 failure
 		rb.hostsV1fallback = true
@@ -118,24 +124,24 @@ func (rb *RepositoryBackend) GetImageInfo(url string) ([]string, *common.ParsedD
 
 	URLSchema, supportsV1, err = rb.supportsRegistry(dockerURL.IndexURL, registryV1)
 	if err != nil {
-		return nil, nil, err
+		return nil, "", nil, err
 	}
 	if !supportsV1 && rb.hostsV1fallback {
-		return nil, nil, fmt.Errorf("attempted fallback to API v1 but not supported")
+		return nil, "", nil, fmt.Errorf("attempted fallback to API v1 but not supported")
 	}
 	if !supportsV1 && !supportsV2 {
-		return nil, nil, fmt.Errorf("registry doesn't support API v2 nor v1")
+		return nil, "", nil, fmt.Errorf("registry doesn't support API v2 nor v1")
 	}
 	rb.schema = URLSchema + "://"
 	// try v1, hard fail on failure
 	return rb.getImageInfoV1(dockerURL)
 }
 
-func (rb *RepositoryBackend) BuildACI(layerIDs []string, dockerURL *common.ParsedDockerURL, outputDir string, tmpBaseDir string, compression common.Compression) ([]string, []*schema.ImageManifest, error) {
+func (rb *RepositoryBackend) BuildACI(layerIDs []string, manhash string, dockerURL *common.ParsedDockerURL, outputDir string, tmpBaseDir string, compression common.Compression) ([]string, []*schema.ImageManifest, error) {
 	if rb.hostsV1fallback || !rb.hostsV2Support[dockerURL.IndexURL] {
-		return rb.buildACIV1(layerIDs, dockerURL, outputDir, tmpBaseDir, compression)
+		return rb.buildACIV1(layerIDs, manhash, dockerURL, outputDir, tmpBaseDir, compression)
 	} else {
-		return rb.buildACIV2(layerIDs, dockerURL, outputDir, tmpBaseDir, compression)
+		return rb.buildACIV2(layerIDs, manhash, dockerURL, outputDir, tmpBaseDir, compression)
 	}
 }
 

--- a/lib/tests/v22_test.go
+++ b/lib/tests/v22_test.go
@@ -162,6 +162,10 @@ func expectedManifest(registryUrl, imageName, imageOs, imageArch string) schema.
 				// Different each testrun for unknown reasons
 			},
 			{
+				Name:  *types.MustACIdentifier("appc.io/docker/manifesthash"),
+				Value: variableTestValue,
+			},
+			{
 				Name:  *types.MustACIdentifier("appc.io/docker/originalname"),
 				Value: imageName,
 			},


### PR DESCRIPTION
There are two commits in here. In order they:
1. Add an annotation to produced ACIs with a hash of the original docker manifest (or sometimes the app ID depending on the version of the HTTP API used)
2. tweaks the library API so that callers can provide a list of manifest hashes they already have

These two changes should allow for rkt to provide a list of docker manifest hashes (obtained by ACI manifest annotations) for images it already has but wants docker2aci to check for an update for. If docker2aci pulls the manifest for an image and it's in the list of images already owned by the caller, it doesn't have to download the image.

This is part of the work for https://github.com/coreos/rkt/issues/2937