### PR TITLE
docker2aci v0.16.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## v0.16.0
+
+This release adds a manifest hash annotation on converted images and introduces some API changes to allow for more granular control on registries and media types.
+
+ - Annotate manifest hash ([#237](https://github.com/appc/docker2aci/pull/237)).
+ - Allow selective disabling of registries and media types ([#239](https://github.com/appc/docker2aci/pull/239)).
+ - Update appc/spec to 0.8.10 ([#242](https://github.com/appc/docker2aci/pull/242)).
+
 ## v0.15.0
 
 This release improves translation of arch labels and image name annotations. It also changes the default output image filename.

--- a/lib/version.go
+++ b/lib/version.go
@@ -16,5 +16,5 @@ package docker2aci
 
 import "github.com/appc/spec/schema"
 
-var Version = "0.16.0"
+var Version = "0.16.0+git"
 var AppcVersion = schema.AppContainerVersion

--- a/lib/version.go
+++ b/lib/version.go
@@ -16,5 +16,5 @@ package docker2aci
 
 import "github.com/appc/spec/schema"
 
-var Version = "0.15.0+git"
+var Version = "0.16.0"
 var AppcVersion = schema.AppContainerVersion


### PR DESCRIPTION
This release adds a manifest hash annotation on converted images, and introduces some API changes to allow for more granular control on registries and media types.

 - Annotate manifest hash ([#237](https://github.com/appc/docker2aci/pull/237)).
 - Allow selective disabling of registries and media types ([#239](https://github.com/appc/docker2aci/pull/239)).
 - Update appc/spec to 0.8.10 ([#242](https://github.com/appc/docker2aci/pull/242)).

