### PR TITLE
Avoid panicing on scratch images

### DIFF
--- a/lib/docker2aci.go
+++ b/lib/docker2aci.go
@@ -150,6 +150,9 @@ func (c *converter) convert() ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
+	if len(ancestry) == 0 {
+		return nil, fmt.Errorf("backend image had no useful layers: not creating ACI")
+	}
 	for _, h := range c.config.CurrentManifestHashes {
 		if manhash == h {
 			return nil, nil


### PR DESCRIPTION
Docker allows creating empty images (e.g. with FROM scratch followed by
a no-op like MAINTAINER or LABEL).

Without this patch, docker2aci will panic when it encounters an image of
this sort.

These images are more-or-less useless. They're also difficult to work
with. As an example, `docker save` bails on them with an `unimplemented`
error.

In line with that behavior, I think bailing in docker2aci makes sense
too rather than dealing with more robust error handling or creating an
empty ACI.