### PR TITLE
lib: add signed manifest media type

### DIFF
--- a/lib/common/common.go
+++ b/lib/common/common.go
@@ -159,6 +159,7 @@ func (m MediaTypeSet) ManifestMediaTypes() []string {
 	if len(m) == 0 {
 		return []string{
 			MediaTypeDockerV21Manifest,
+			MediaTypeDockerV21SignedManifest,
 			MediaTypeDockerV22Manifest,
 			MediaTypeOCIV1Manifest,
 		}
@@ -168,6 +169,7 @@ func (m MediaTypeSet) ManifestMediaTypes() []string {
 		switch option {
 		case MediaTypeOptionDockerV21:
 			ret = append(ret, MediaTypeDockerV21Manifest)
+			ret = append(ret, MediaTypeDockerV21SignedManifest)
 		case MediaTypeOptionDockerV22:
 			ret = append(ret, MediaTypeDockerV22Manifest)
 		case MediaTypeOptionOCIV1Pre:

--- a/lib/common/common_test.go
+++ b/lib/common/common_test.go
@@ -29,7 +29,7 @@ func TestMediaTypeSet(t *testing.T) {
 	}{
 		{
 			MediaTypeSet{MediaTypeOptionDockerV21},
-			[]string{MediaTypeDockerV21Manifest},
+			[]string{MediaTypeDockerV21Manifest, MediaTypeDockerV21SignedManifest},
 			[]string{},
 			[]string{},
 		},
@@ -47,19 +47,19 @@ func TestMediaTypeSet(t *testing.T) {
 		},
 		{
 			MediaTypeSet{},
-			[]string{MediaTypeDockerV21Manifest, MediaTypeDockerV22Manifest, MediaTypeOCIV1Manifest},
+			[]string{MediaTypeDockerV21Manifest, MediaTypeDockerV21SignedManifest, MediaTypeDockerV22Manifest, MediaTypeOCIV1Manifest},
 			[]string{MediaTypeDockerV22Config, MediaTypeOCIV1Config},
 			[]string{MediaTypeDockerV22RootFS, MediaTypeOCIV1Layer},
 		},
 		{
 			MediaTypeSet{MediaTypeOptionDockerV21, MediaTypeOptionDockerV22, MediaTypeOptionOCIV1Pre},
-			[]string{MediaTypeDockerV21Manifest, MediaTypeDockerV22Manifest, MediaTypeOCIV1Manifest},
+			[]string{MediaTypeDockerV21Manifest, MediaTypeDockerV21SignedManifest, MediaTypeDockerV22Manifest, MediaTypeOCIV1Manifest},
 			[]string{MediaTypeDockerV22Config, MediaTypeOCIV1Config},
 			[]string{MediaTypeDockerV22RootFS, MediaTypeOCIV1Layer},
 		},
 		{
 			MediaTypeSet{MediaTypeOptionDockerV21, MediaTypeOptionOCIV1Pre},
-			[]string{MediaTypeDockerV21Manifest, MediaTypeOCIV1Manifest},
+			[]string{MediaTypeDockerV21Manifest, MediaTypeDockerV21SignedManifest, MediaTypeOCIV1Manifest},
 			[]string{MediaTypeOCIV1Config},
 			[]string{MediaTypeOCIV1Layer},
 		},


### PR DESCRIPTION
Some registries serve signed manifests and refuse to deliver them (error
404) unless the client specifies the correct Accept header:

    $ docker2aci docker://gcr.io/google_containers/busybox:1.24
    Error: conversion error: attempted fallback to API v1 but not supported

    $ curl --header 'Accept: application/vnd.docker.distribution.manifest.v1+json' \
      -i https://gcr.io/v2/google_containers/busybox/manifests/1.24
    HTTP/2 404
    docker-distribution-api-version: registry/2.0
    content-type: application/json
    date: Fri, 20 Oct 2017 09:29:29 GMT
    server: Docker Registry
    cache-control: private
    x-xss-protection: 1; mode=block
    x-frame-options: SAMEORIGIN
    alt-svc: quic=":443"; ma=2592000; v="39,38,37,35"
    accept-ranges: none
    vary: Accept-Encoding

    {"errors":[{"code":"MANIFEST_UNKNOWN","message":"Manifest with tag
    '1.24' has media type 'application/vnd.docker.distribution.manifest.v1+prettyjws',
    but client accepts 'applicatio/vnd.docker.distribution.manifest.v1+json'."}]}

This adds the signed manifest media type to the default used media types
(and when V2.1 is requested) so we can fetch those images:

    $ curl \
      --header \
      'Accept: application/vnd.docker.distribution.manifest.v1+json,application/vnd.docker.distribution.manifest.v1+prettyjws' \
      -i https://gcr.io/v2/google_containers/busybox/manifests/1.24
    HTTP/2 200
    docker-distribution-api-version: registry/2.0
    content-type: application/vnd.docker.distribution.manifest.v1+prettyjws
    content-length: 3205
    docker-content-digest: sha256:4bdd623e848417d96127e16037743f0cd8b528c026e9175e22a84f639eca58ff
    date: Fri, 20 Oct 2017 09:32:01 GMT
    server: Docker Registry
    x-xss-protection: 1; mode=block
    x-frame-options: SAMEORIGIN
    alt-svc: quic=":443"; ma=2592000; v="39,38,37,35"

    $ docker2aci docker://gcr.io/google_containers/busybox:1.24
    Downloading sha256:a3ed95caeb0 [===============================]     32 B / 32 B
    Downloading sha256:eeee0535bf3 [===============================] 676 KB / 676 KB

    Generated ACI(s):
    google_containers-busybox-1.24.aci

Fixes #254 