### PR TITLE
docker2aci: release v0.17.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
+## v0.17.2
+
+This is a bugfix release to ensure compatibility with newer go-1.10 toolchain.
+
+ - lib/internal: fix tar header format ([#260](https://github.com/appc/docker2aci/pull/260)).
+ - tests: update script to run within gopath ([#261](https://github.com/appc/docker2aci/pull/261)).
+
 ## v0.17.1
 
 This is a bugfix release that fixes pulling certain images from the Google Container Registry.

--- a/lib/version.go
+++ b/lib/version.go
@@ -16,5 +16,5 @@ package docker2aci
 
 import "github.com/appc/spec/schema"
 
-var Version = "0.17.1+git"
+var Version = "0.17.2"
 var AppcVersion = schema.AppContainerVersion

--- a/lib/version.go
+++ b/lib/version.go
@@ -16,5 +16,5 @@ package docker2aci
 
 import "github.com/appc/spec/schema"
 
-var Version = "0.17.2"
+var Version = "0.17.2+git"
 var AppcVersion = schema.AppContainerVersion


### PR DESCRIPTION
## v0.17.2

This is a bugfix release to ensure compatibility with newer go-1.10 toolchain.

 - lib/internal: fix tar header format ([#260](https://github.com/appc/docker2aci/pull/260)).
 - tests: update script to run within gopath ([#261](https://github.com/appc/docker2aci/pull/261)).
